### PR TITLE
feat: nuova UI da design (stacked su #62)

### DIFF
--- a/docs/ui-redesign.md
+++ b/docs/ui-redesign.md
@@ -1,0 +1,94 @@
+# UI redesign — DevFest Modena
+
+Migration of the Astro site to the new design language provided by the designer.
+
+## Design language
+
+| Trait       | Decision                                                                             |
+| ----------- | ------------------------------------------------------------------------------------ |
+| Background  | White page, **periwinkle panels** (`--color-panel`) for the key content blocks       |
+| Cards       | White, 1px hairline border, large radius, no shadow at rest                          |
+| Buttons     | Pill; **primary = ink (near-black)**, **secondary = outlined on white**              |
+| Badges      | Pill, pastel Google tint + matching dark ink text (`.badge--green`, `--blue`, …)     |
+| Headings    | Google Sans Display 700, tight tracking (`--tracking-tight`), centered in sections   |
+| Accents     | The four Google colours, used as _punctuation_ (dot divider, stat underlines, decor) |
+| Decorations | Flat geometric shapes (arrow, cross, squares) — `Decor.astro`                        |
+| Radii       | `--radius-m` cards · `--radius-l` panels · `--radius-full` pills                     |
+
+Everything is driven by tokens in `src/styles/variables.css`; components never hardcode colours.
+
+### Layout rails
+
+- `.container` — outer rail (`--container`): panels, footer and the photo strip reach this edge.
+- `.container--inset` — copy and card grids, slightly narrower so they sit inside the panels.
+- `.container--narrow` — long-form reading width (FAQ, editorial pages, archive).
+
+### Gotcha: scoped styles and child components
+
+Astro scopes styles with a `data-astro-cid-*` attribute on the elements of **its own**
+template. A component that does not spread `Astro.props` onto its root never receives the
+parent's attribute, so a `class` passed down cannot be styled from the parent. Position and
+space child components from a wrapper element you own (see `PromoCard` → `.promo-decor`),
+and keep shared looks (`.panel`, `.badge`, `.card`, `.logo-tile`, `.inline-list`) in
+`global.css`.
+
+## Checklist
+
+### Foundations
+
+- [x] `variables.css` — new palette, panel/card tokens, tracking, radii, container widths
+- [x] `global.css` — buttons, badges, cards, panels, dot divider, prose, layout primitives
+- [x] `themes.css` — per-edition accent kept working with the new palette
+- [x] Dark-mode pass over every new token (design is light-only, dark is derived)
+
+### Shared components
+
+- [x] `Header.astro` — white bar, `{DevFest}` logo, plain nav, ink CTA, restyled burger
+- [x] `Footer.astro` — dark block, 4 columns (brand / sitemap / patronage / contacts) + bottom bar
+- [x] `Decor.astro` — arrow, cross and squares ornaments (new)
+- [x] `.panel` / `.panel--center` / `.panel--split` — periwinkle content blocks (global.css)
+- [x] `PromoCard.astro` — badge + title + text + action card (new, used by CFS and CV)
+- [x] `Gallery.astro` — edge-bleeding photo strip (new)
+- [x] `PageHeader.astro` — shared interior-page header (new)
+- [x] `SectionHeading.astro` — centered variant with optional kicker and lead
+- [x] `Statistics.astro` — white cards, big figure, coloured underline
+- [x] `PartnerGrid.astro` — centered tier labels, white logo tiles, per-tier sizes
+- [x] `CommunitiesGrid.astro` — logo tiles aligned with partners
+- [x] `PersonCard.astro` — new photo treatment and typography
+- [x] `SessionList.astro` — card rows, new time column and badges
+- [x] `Callout.astro` — flat tinted block, no left rule
+- [x] `CtaTickets.astro` — periwinkle panel with photo
+- [x] `CtaCv.astro` — promo card with green badge
+
+### Pages
+
+- [x] Home — hero, intro panel, gallery, CFS, stats, partners, communities, editions
+- [x] Agenda (`AgendaPage`)
+- [x] Session detail (`SessionPage`)
+- [x] Speakers index + speaker detail
+- [x] Team
+- [x] Communities
+- [x] Partners index + partner detail
+- [x] Rooms index + room detail
+- [x] Location
+- [x] FAQ
+- [x] Archive + edition hub
+- [x] Markdown pages (workshops, speed networking, code of conduct)
+- [x] 404
+
+### Content / copy
+
+- [x] i18n strings aligned with the designer's copy (hero claim, CTA labels, badges)
+- [x] Dropped the duplicate `<h1>` from the workshops / speed-networking markdown:
+      the page renders the frontmatter title itself
+- [x] Italian dates are sentence-cased in TS (`sentenceCase`) instead of `text-transform`,
+      which was capitalising every word ("4 E 5 Ottobre")
+
+### Quality
+
+- [x] `pnpm build` clean (461 pages), `astro check` clean (0 errors, 0 warnings)
+- [x] Prettier formatting — the agenda enhancement script moved out of the JSX
+      expression it was nested in, which Prettier could not parse
+- [x] Responsive pass (mobile / tablet / desktop)
+- [x] A11y pass — one `h1` per page, labelled landmarks, alt text, focus rings,
+      WCAG AA contrast in both schemes (lowest measured pair 5.15:1)

--- a/src/components/Callout.astro
+++ b/src/components/Callout.astro
@@ -15,18 +15,26 @@ const { variant = "info", role } = Astro.props;
   .callout {
     padding: var(--space-s) var(--space-m);
     border-radius: var(--radius-m);
-    border: 1px solid var(--color-border);
     margin-block: var(--space-s);
+    font-size: var(--text--1);
   }
 
   .callout--info {
     background: var(--g-blue-soft);
-    border-inline-start: 5px solid var(--g-blue);
+    color: var(--g-blue-ink);
   }
 
   .callout--warning {
     background: var(--g-yellow-soft);
-    border-inline-start: 5px solid var(--g-yellow);
+    color: var(--g-yellow-ink);
+  }
+
+  .callout :global(a) {
+    color: inherit;
+  }
+
+  .callout :global(strong) {
+    color: inherit;
   }
 
   .callout :global(p) {

--- a/src/components/CommunitiesGrid.astro
+++ b/src/components/CommunitiesGrid.astro
@@ -32,12 +32,12 @@ const communities = (
     communities.map((community) => (
       <li>
         <a
-          class="card community"
+          class="community"
           href={withUtm(community.website, year)}
           target="_blank"
           rel="noopener"
         >
-          <span class="logo">
+          <span class="logo-tile">
             {community.logo ? (
               <Image
                 src={community.logo}
@@ -63,7 +63,7 @@ const communities = (
     list-style: none;
     padding: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(10rem, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(9rem, 1fr));
     gap: var(--space-s);
   }
 
@@ -72,35 +72,35 @@ const communities = (
     justify-items: center;
     gap: var(--space-2xs);
     text-align: center;
+    text-decoration: none;
   }
 
-  .logo {
-    display: grid;
-    place-items: center;
+  .community .logo-tile {
     width: 100%;
     aspect-ratio: 1;
-    background: oklch(99% 0 0);
-    border-radius: var(--radius-m);
-    padding: var(--space-2xs);
+    transition:
+      border-color var(--transition),
+      transform var(--transition);
   }
 
-  .logo img {
-    max-width: 82%;
-    max-height: 82%;
-    width: auto;
-    height: auto;
-    object-fit: contain;
+  .community:hover .logo-tile {
+    border-color: var(--color-border-strong);
+    transform: translateY(-2px);
+  }
+
+  .community img {
+    max-width: 78%;
+    max-height: 78%;
   }
 
   .logo-placeholder {
     font-size: var(--text-4);
     font-weight: 700;
-    color: oklch(60% 0.02 270);
+    color: var(--color-text-muted);
   }
 
   .name {
     color: var(--color-text);
     font-size: var(--text--1);
-    font-weight: 400;
   }
 </style>

--- a/src/components/CtaCv.astro
+++ b/src/components/CtaCv.astro
@@ -1,4 +1,5 @@
 ---
+import PromoCard from "@components/PromoCard.astro";
 import { CURRENT_EDITION } from "@configs/editions";
 import { useTranslations, type Locale } from "@i18n/index";
 
@@ -13,44 +14,24 @@ const cvFormUrl = CURRENT_EDITION.cvFormUrl;
 
 {
   cvFormUrl && (
-    <section class="cta-cv" aria-label={t("cta.cv.title")}>
-      <h2>{t("cta.cv.title")}</h2>
-      <p>{t("cta.cv.text")}</p>
-      <a
-        class="button button--secondary"
-        href={cvFormUrl}
-        target="_blank"
-        rel="noopener"
-      >
-        {t("cta.cv.button")}
-      </a>
-    </section>
+    <div class="cta-cv">
+      <PromoCard
+        badge={t("cta.cv.badge")}
+        title={t("cta.cv.title")}
+        text={t("cta.cv.text")}
+        action={{
+          label: t("cta.cv.button"),
+          href: cvFormUrl,
+          external: true,
+        }}
+        decor={{ shape: "squares", tone: "yellow" }}
+      />
+    </div>
   )
 }
 
 <style>
   .cta-cv {
-    display: grid;
-    justify-items: center;
-    text-align: center;
-    gap: var(--space-2xs);
-    margin-block: var(--space-l);
-    padding: var(--space-l);
-    border-radius: var(--radius-l);
-    border: 1px dashed var(--color-border-strong);
-    background: var(--g-green-soft);
-  }
-
-  h2 {
-    font-size: var(--text-2);
-  }
-
-  p {
-    max-width: 52ch;
-  }
-
-  .button {
-    margin-top: var(--space-2xs);
-    background: var(--color-bg);
+    margin-block: var(--space-2xl) var(--space-l);
   }
 </style>

--- a/src/components/CtaTickets.astro
+++ b/src/components/CtaTickets.astro
@@ -1,5 +1,5 @@
 ---
-import logoSimple from "@assets/images/logo-simple.png";
+import ticketsPhoto from "@assets/gallery/sp_networking.jpg";
 import { CURRENT_EDITION, CURRENT_YEAR } from "@configs/editions";
 import { useTranslations, type Locale } from "@i18n/index";
 import { Image } from "astro:assets";
@@ -15,26 +15,26 @@ const ticketsUrl = CURRENT_EDITION.ticketsUrl;
 
 {
   ticketsUrl && (
-    <section class="cta-tickets" aria-label={t("cta.tickets.title")}>
+    <section
+      class="panel panel--split cta-tickets"
+      aria-label={t("cta.tickets.title")}
+    >
       <div class="content">
         <h2>{t("cta.tickets.title")}</h2>
         <p>{t("cta.tickets.text1", { year: CURRENT_YEAR })}</p>
         <p>{t("cta.tickets.text2")}</p>
-        <a
-          class="button button--light"
-          href={ticketsUrl}
-          target="_blank"
-          rel="noopener"
-        >
+        <a class="button" href={ticketsUrl} target="_blank" rel="noopener">
           {t("cta.tickets.button")}
         </a>
       </div>
       <Image
-        class="logo"
-        src={logoSimple}
+        class="photo"
+        src={ticketsPhoto}
         alt=""
-        width="340"
+        width={640}
+        height={440}
         densities={[1, 2]}
+        loading="lazy"
       />
     </section>
   )
@@ -42,63 +42,32 @@ const ticketsUrl = CURRENT_EDITION.ticketsUrl;
 
 <style>
   .cta-tickets {
-    position: relative;
-    overflow: hidden;
-    display: grid;
-    grid-template-columns: 1.6fr 1fr;
-    align-items: center;
-    gap: var(--space-m);
     margin-block: var(--space-l);
-    padding: var(--space-l) var(--space-m-l, var(--space-l));
-    border-radius: var(--radius-l);
-    background:
-      radial-gradient(
-        120% 160% at 100% 0%,
-        oklch(70% 0.14 250 / 0.55),
-        transparent 55%
-      ),
-      radial-gradient(
-        100% 140% at 0% 100%,
-        oklch(55% 0.15 150 / 0.4),
-        transparent 50%
-      ),
-      var(--color-footer-bg);
-    color: var(--color-footer-text);
+  }
+
+  .content {
+    display: grid;
+    justify-items: start;
+    gap: var(--space-2xs);
   }
 
   h2 {
-    color: oklch(99% 0 0);
     font-size: var(--text-3);
-    margin-bottom: var(--space-xs);
   }
 
   p {
-    margin-bottom: 0.35em;
-    max-width: 44ch;
+    max-width: 46ch;
+    font-size: var(--text--1);
   }
 
   .button {
     margin-top: var(--space-s);
   }
 
-  .logo {
-    justify-self: center;
-    width: min(14rem, 60%);
-    height: auto;
-    rotate: -6deg;
-    border-radius: var(--radius-l);
-    background: oklch(99% 0 0);
-    padding: 1rem;
-    box-shadow: var(--shadow-2);
-  }
-
-  @media (max-width: 39.9375em) {
-    .cta-tickets {
-      grid-template-columns: 1fr;
-    }
-
-    .logo {
-      display: none;
-    }
+  .photo {
+    width: 100%;
+    aspect-ratio: 3 / 2;
+    object-fit: cover;
+    border-radius: var(--radius-m);
   }
 </style>

--- a/src/components/Decor.astro
+++ b/src/components/Decor.astro
@@ -1,0 +1,77 @@
+---
+/**
+ * Flat geometric ornaments from the design language (arrow, cross, squares).
+ * Purely decorative: always rendered aria-hidden and hidden in print.
+ */
+/**
+ * Position it from the outside by wrapping it in an element you own:
+ * Astro scoped styles do not reach a class passed to a child component.
+ */
+interface Props {
+  shape: keyof typeof shapes;
+  tone?: "yellow" | "pink" | "blue" | "green" | "red";
+  /** Rendered width in rem; the height follows the shape's aspect ratio. */
+  size?: number;
+}
+
+const shapes = {
+  /** Stubby right arrow next to the hero title. */
+  arrow: {
+    viewBox: "0 0 64 32",
+    ratio: 32 / 64,
+    path: "M0 12h34V2a2 2 0 0 1 3.4-1.4l25 14.2a2 2 0 0 1 0 2.4l-25 14.2A2 2 0 0 1 34 30V20H0z",
+  },
+  /** Rounded X used as a punctuation mark between sections. */
+  cross: {
+    viewBox: "0 0 40 40",
+    ratio: 1,
+    path: "M8.6 2.5 20 13.9 31.4 2.5a4.3 4.3 0 0 1 6.1 6.1L26.1 20l11.4 11.4a4.3 4.3 0 0 1-6.1 6.1L20 26.1 8.6 37.5a4.3 4.3 0 0 1-6.1-6.1L13.9 20 2.5 8.6a4.3 4.3 0 0 1 6.1-6.1Z",
+  },
+  /** Two overlapping outlined squares. */
+  squares: {
+    viewBox: "0 0 48 48",
+    ratio: 1,
+    path: "M17.7 3.5 32.9 8.6a2 2 0 0 1 1.3 2.5l-5.1 15.2a2 2 0 0 1-2.5 1.3L11.4 22.5a2 2 0 0 1-1.3-2.5l5.1-15.2a2 2 0 0 1 2.5-1.3Zm-1.2 4.9-3.9 11.4 11.4 3.9 3.9-11.4-11.4-3.9ZM31 19.6l13.9 7.7a2 2 0 0 1 .8 2.7L38 43.9a2 2 0 0 1-2.7.8l-13.9-7.7a2 2 0 0 1-.8-2.7l7.7-13.9a2 2 0 0 1 2.7-.8Zm-.4 4.9-5.8 10.4 10.4 5.8 5.8-10.4-10.4-5.8Z",
+  },
+} as const;
+
+const { shape, tone = "yellow", size = 4 }: Props = Astro.props;
+const { viewBox, ratio, path } = shapes[shape];
+---
+
+<svg
+  class:list={["decor", `decor--${tone}`]}
+  width={`${size}rem`}
+  height={`${size * ratio}rem`}
+  {viewBox}
+  fill="currentColor"
+  aria-hidden="true"
+>
+  <path d={path}></path>
+</svg>
+
+<style>
+  .decor {
+    flex-shrink: 0;
+  }
+
+  .decor--yellow {
+    color: var(--g-yellow);
+  }
+
+  .decor--pink {
+    color: var(--g-pink);
+  }
+
+  .decor--blue {
+    color: var(--g-blue);
+  }
+
+  .decor--green {
+    color: var(--g-green);
+  }
+
+  .decor--red {
+    color: var(--g-red);
+  }
+</style>

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -1,16 +1,12 @@
 ---
 import logoGdg from "@assets/communities/gdg-cloud-modena.png";
-import logoSimple from "@assets/images/logo-simple.png";
 import Icon from "@components/Icon.astro";
-import {
-  CURRENT_EDITION,
-  CURRENT_YEAR,
-  EDITION_YEARS,
-} from "@configs/editions";
+import { CURRENT_YEAR, EDITION_YEARS } from "@configs/editions";
 import {
   COPYRIGHT_FROM_YEAR,
   EMAIL,
   ORGANIZER,
+  SITE_NAME,
   SOCIAL,
   withUtm,
   WTM_URL,
@@ -50,155 +46,114 @@ const socialIcons = {
 
 const sitemapLinks = [
   { label: t("nav.agenda"), href: `/${CURRENT_YEAR}/sessions/` },
-  { label: t("nav.speakers"), href: `/${CURRENT_YEAR}/speakers/` },
+  { label: t("nav.faq"), href: "/faq/" },
   { label: t("nav.team"), href: `/${CURRENT_YEAR}/team/` },
+  { label: t("nav.speakers"), href: `/${CURRENT_YEAR}/speakers/` },
   { label: t("nav.communities"), href: `/${CURRENT_YEAR}/communities/` },
   { label: t("footer.partners"), href: "/partners/" },
-  { label: t("nav.location"), href: "/location/" },
-  { label: t("nav.faq"), href: "/faq/" },
   { label: t("footer.workshops"), href: "/workshops/" },
   { label: t("footer.speedNetworking"), href: "/speed-networking/" },
+  { label: t("nav.location"), href: "/location/" },
   { label: t("footer.coc"), href: "/code-of-conduct/" },
 ];
 ---
 
 <footer class="site-footer">
-  <div class="container">
-    <div class="columns">
-      <div class="col col--brand">
-        <div class="logos">
-          <span class="logo-tile">
-            <Image
-              src={logoSimple}
-              alt="DevFest Modena"
-              width="96"
-              densities={[1, 2]}
-            />
-          </span>
-          <span class="logo-tile">
-            <Image
-              src={logoGdg}
-              alt={ORGANIZER}
-              width="96"
-              densities={[1, 2]}
-            />
-          </span>
-        </div>
-        <p class="description">{t("footer.description")}</p>
-        <ul class="social" role="list">
-          {
-            Object.entries(SOCIAL).map(([name, url]) => (
-              <li>
-                <a href={url} target="_blank" rel="noopener" aria-label={name}>
-                  <Icon
-                    name={socialIcons[name as keyof typeof socialIcons]}
-                    size={22}
-                  />
-                </a>
-              </li>
-            ))
-          }
-          <li>
-            <a href={`mailto:${EMAIL}`} aria-label="Email">
-              <Icon name="email" size={22} />
-            </a>
-          </li>
-        </ul>
-        <p><a class="footer-link" href={`mailto:${EMAIL}`}>{EMAIL}</a></p>
-      </div>
-
-      <nav class="col" aria-label={t("footer.sitemap")}>
-        <h2 class="title">{t("footer.sitemap")}</h2>
-        <ul role="list">
-          {
-            sitemapLinks.map((link) => (
-              <li>
-                <a class="footer-link" href={l(link.href)}>
-                  {link.label}
-                </a>
-              </li>
-            ))
-          }
-        </ul>
-      </nav>
-
-      <nav class="col" aria-label={t("footer.editions")}>
-        <h2 class="title">{t("footer.editions")}</h2>
-        <ul role="list">
-          {
-            EDITION_YEARS.map((y) => (
-              <li>
-                <a class="footer-link" href={l(`/${y}/`)}>
-                  DevFest Modena {y}
-                </a>
-              </li>
-            ))
-          }
-          <li>
-            <a class="footer-link" href={l("/archive/")}>{t("nav.archive")}</a>
-          </li>
-          <li>
-            <a
-              class="footer-link"
-              href={WTM_URL}
-              target="_blank"
-              rel="noopener"
-            >
-              Women Techmakers Modena
-            </a>
-          </li>
-        </ul>
-        {
-          CURRENT_EDITION.ticketsUrl && (
-            <p class="tickets">
-              <a
-                class="button"
-                href={CURRENT_EDITION.ticketsUrl}
-                target="_blank"
-                rel="noopener"
-              >
-                {t("nav.tickets")}
-              </a>
-            </p>
-          )
-        }
-      </nav>
-
-      <div class="col">
-        <h2 class="title">{t("footer.patronage")}</h2>
-        <ul class="patrocini" role="list">
-          {
-            patrocini.map((p) => {
-              const logo = partnerLogo(CURRENT_YEAR, p.code);
-              return (
-                <li>
-                  <a
-                    class="patrocini-item"
-                    href={withUtm(p.link, CURRENT_YEAR)}
-                    target="_blank"
-                    rel="noopener"
-                  >
-                    {logo && (
-                      <span class="logo-tile logo-tile--small">
-                        <Image
-                          src={logo}
-                          alt=""
-                          width="120"
-                          densities={[1, 2]}
-                        />
-                      </span>
-                    )}
-                    <span>{p.name}</span>
-                  </a>
-                </li>
-              );
-            })
-          }
-        </ul>
-      </div>
+  <div class="container columns">
+    <div class="col col--brand">
+      <a class="wordmark" href={l("/")} aria-label={SITE_NAME}>
+        <span aria-hidden="true">&#123;</span>DevFest<span aria-hidden="true"
+          >&#125;</span
+        >
+      </a>
+      <p class="description">{t("footer.description")}</p>
+      <span class="logo-tile organizer">
+        <Image src={logoGdg} alt={ORGANIZER} width="96" densities={[1, 2]} />
+      </span>
     </div>
 
+    <nav class="col" aria-label={t("footer.sitemap")}>
+      <h2 class="title">{t("footer.sitemap")}</h2>
+      <ul role="list">
+        {
+          sitemapLinks.map((link) => (
+            <li>
+              <a class="footer-link" href={l(link.href)}>
+                {link.label}
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+    </nav>
+
+    <div class="col">
+      <h2 class="title">{t("footer.patronage")}</h2>
+      <ul class="patrocini" role="list">
+        {
+          patrocini.map((p) => {
+            const logo = partnerLogo(CURRENT_YEAR, p.code);
+            return (
+              <li>
+                <a
+                  class="patrocini-item"
+                  href={withUtm(p.link, CURRENT_YEAR)}
+                  target="_blank"
+                  rel="noopener"
+                >
+                  {logo && (
+                    <span class="logo-tile">
+                      <Image src={logo} alt="" width="120" densities={[1, 2]} />
+                    </span>
+                  )}
+                  <span>{p.name}</span>
+                </a>
+              </li>
+            );
+          })
+        }
+      </ul>
+    </div>
+
+    <div class="col">
+      <h2 class="title">{t("footer.contacts")}</h2>
+      <p>
+        <a class="footer-link" href={`mailto:${EMAIL}`}>{EMAIL}</a>
+      </p>
+      <ul class="social" role="list">
+        {
+          Object.entries(SOCIAL).map(([name, url]) => (
+            <li>
+              <a href={url} target="_blank" rel="noopener" aria-label={name}>
+                <Icon
+                  name={socialIcons[name as keyof typeof socialIcons]}
+                  size={20}
+                />
+              </a>
+            </li>
+          ))
+        }
+      </ul>
+      <p>
+        <a class="footer-link" href={WTM_URL} target="_blank" rel="noopener">
+          Women Techmakers Modena
+        </a>
+      </p>
+    </div>
+  </div>
+
+  <div class="container bottom">
     <p class="copy">© {copyright} {ORGANIZER}</p>
+    <nav class="editions" aria-label={t("footer.editions")}>
+      {
+        EDITION_YEARS.map((y) => (
+          <a class="footer-link" href={l(`/${y}/`)}>
+            {y}
+          </a>
+        ))
+      }
+      <a class="footer-link" href={l("/archive/")}>{t("nav.archive")}</a>
+    </nav>
   </div>
 </footer>
 
@@ -206,14 +161,14 @@ const sitemapLinks = [
   .site-footer {
     background: var(--color-footer-bg);
     color: var(--color-footer-text);
-    padding-block: var(--space-xl) var(--space-l);
+    padding-block: var(--space-xl) var(--space-m);
     margin-top: var(--space-2xl);
     font-size: var(--text--1);
   }
 
   .columns {
     display: grid;
-    grid-template-columns: 1.4fr 1fr 1fr 1fr;
+    grid-template-columns: 1.5fr 1fr 1fr 1fr;
     gap: var(--space-l);
   }
 
@@ -221,42 +176,42 @@ const sitemapLinks = [
     list-style: none;
     padding: 0;
     display: grid;
-    gap: 0.45em;
+    gap: 0.5em;
   }
 
   .title {
-    font-size: var(--text-0);
-    color: var(--g-yellow);
+    font-size: var(--text--1);
+    font-weight: 700;
+    letter-spacing: var(--tracking-wide);
+    text-transform: uppercase;
+    color: var(--color-footer-muted);
     margin-bottom: var(--space-xs);
   }
 
-  .logos {
-    display: flex;
-    gap: var(--space-2xs);
-    margin-bottom: var(--space-s);
-  }
-
-  .logo-tile {
+  .wordmark {
     display: inline-block;
-    background: oklch(99% 0 0);
-    border-radius: var(--radius-m);
-    padding: 0.5rem;
+    font-size: var(--text-2);
+    font-weight: 700;
+    letter-spacing: var(--tracking-tight);
+    color: oklch(100% 0 0);
+    text-decoration: none;
   }
 
-  .logo-tile img {
-    width: 4.5rem;
-    height: 4.5rem;
-    object-fit: contain;
-  }
-
-  .logo-tile--small img {
-    width: 3.25rem;
-    height: 3.25rem;
+  .wordmark span {
+    color: var(--g-yellow);
   }
 
   .description {
-    margin-bottom: var(--space-s);
-    max-width: 32ch;
+    margin-block: var(--space-xs) var(--space-s);
+    color: var(--color-footer-muted);
+    max-width: 34ch;
+  }
+
+  .organizer {
+    width: 5.5rem;
+    aspect-ratio: 1;
+    padding: 0.6rem;
+    border-color: transparent;
   }
 
   .footer-link {
@@ -270,9 +225,9 @@ const sitemapLinks = [
 
   .social {
     display: flex !important;
-    grid-auto-flow: column;
-    gap: 0.75rem !important;
-    margin-bottom: var(--space-xs);
+    flex-wrap: wrap;
+    gap: 0.6rem !important;
+    margin-block: var(--space-xs);
   }
 
   .social a {
@@ -281,7 +236,7 @@ const sitemapLinks = [
     width: 2.4rem;
     height: 2.4rem;
     border-radius: 50%;
-    border: 1px solid oklch(100% 0 0 / 0.25);
+    border: 1px solid var(--color-footer-border);
     color: var(--color-footer-text);
     transition:
       background var(--transition),
@@ -298,29 +253,41 @@ const sitemapLinks = [
   }
 
   .patrocini-item {
-    display: flex;
-    align-items: center;
-    gap: var(--space-xs);
+    display: grid;
+    justify-items: start;
+    gap: 0.4rem;
     color: var(--color-footer-text);
     text-decoration: none;
-    opacity: 0.92;
   }
 
-  .patrocini-item:hover {
-    opacity: 1;
+  .patrocini-item:hover span:last-child {
     text-decoration: underline;
   }
 
-  .tickets {
-    margin-top: var(--space-s);
+  .patrocini .logo-tile {
+    width: 5.5rem;
+    aspect-ratio: 3 / 2;
+    padding: 0.5rem;
+    border-color: transparent;
   }
 
-  .copy {
-    margin-top: var(--space-l);
+  .bottom {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--space-xs);
+    margin-top: var(--space-xl);
     padding-top: var(--space-s);
-    border-top: 1px solid oklch(100% 0 0 / 0.15);
-    text-align: center;
-    opacity: 0.85;
+    border-top: 1px solid var(--color-footer-border);
+    color: var(--color-footer-muted);
+    font-size: var(--text--2);
+  }
+
+  .editions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-xs);
   }
 
   @media (max-width: 63.9375em) {

--- a/src/components/Gallery.astro
+++ b/src/components/Gallery.astro
@@ -1,0 +1,69 @@
+---
+import { Image } from "astro:assets";
+import type { ImageMetadata } from "astro";
+
+/**
+ * Horizontal photo strip. It deliberately bleeds past the container on the
+ * end side, as in the design, and scrolls (keyboard included) beyond that.
+ */
+interface Props {
+  photos: { image: ImageMetadata; alt: string }[];
+  label: string;
+}
+
+const { photos, label } = Astro.props;
+---
+
+<div class="gallery" role="region" aria-label={label} tabindex="0">
+  <ul class="track" role="list">
+    {
+      photos.map(({ image, alt }) => (
+        <li class="item">
+          <Image
+            src={image}
+            {alt}
+            width={640}
+            height={420}
+            densities={[1, 2]}
+            loading="lazy"
+          />
+        </li>
+      ))
+    }
+  </ul>
+</div>
+
+<style>
+  .gallery {
+    /* Bleed to the viewport edge so the strip reads as "continuing". */
+    margin-inline-end: calc(
+      -1 * max(var(--gutter), (100vw - var(--container)) / 2)
+    );
+    overflow-x: auto;
+    scroll-snap-type: x proximity;
+    scrollbar-width: none;
+  }
+
+  .gallery::-webkit-scrollbar {
+    display: none;
+  }
+
+  .track {
+    display: flex;
+    gap: var(--space-s);
+    padding: 0;
+    list-style: none;
+    width: max-content;
+  }
+
+  .item {
+    scroll-snap-align: start;
+  }
+
+  .item :global(img) {
+    width: clamp(15rem, 30vi, 23rem);
+    aspect-ratio: 3 / 2;
+    object-fit: cover;
+    border-radius: var(--radius-m);
+  }
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,6 +1,7 @@
 ---
 import logoSimple from "@assets/images/logo-simple.png";
 import { CURRENT_EDITION, CURRENT_YEAR } from "@configs/editions";
+import { SITE_NAME } from "@configs/site";
 import {
   localizePath,
   switchLocalePath,
@@ -18,11 +19,11 @@ const t = useTranslations(locale);
 
 const items = [
   { key: "nav.agenda", href: `/${CURRENT_YEAR}/sessions/` },
-  { key: "nav.speakers", href: `/${CURRENT_YEAR}/speakers/` },
+  { key: "nav.faq", href: "/faq/" },
   { key: "nav.team", href: `/${CURRENT_YEAR}/team/` },
+  { key: "nav.speakers", href: `/${CURRENT_YEAR}/speakers/` },
   { key: "nav.communities", href: `/${CURRENT_YEAR}/communities/` },
   { key: "nav.location", href: "/location/" },
-  { key: "nav.faq", href: "/faq/" },
 ] as const;
 
 const current = Astro.url.pathname.replace(/\/$/, "") + "/";
@@ -35,14 +36,11 @@ const ticketsUrl = CURRENT_EDITION.ticketsUrl;
     <a class="brand" href={localizePath(locale, "/")}>
       <Image
         src={logoSimple}
-        alt=""
-        width="88"
+        alt={SITE_NAME}
+        width="112"
         densities={[1, 2]}
         loading="eager"
       />
-      <span class="brand-text">
-        DevFest <span class="brand-city">Modena</span>
-      </span>
     </a>
 
     <nav class="nav" aria-label={t("nav.menu.label")}>
@@ -157,67 +155,56 @@ const ticketsUrl = CURRENT_EDITION.ticketsUrl;
     position: sticky;
     top: 0;
     z-index: 50;
-    background: color-mix(in oklch, var(--color-bg) 88%, transparent);
-    backdrop-filter: blur(10px);
-    border-bottom: 1px solid var(--color-border);
+    background: color-mix(in oklch, var(--color-bg) 90%, transparent);
+    backdrop-filter: blur(12px);
   }
 
   .bar {
     display: flex;
     align-items: center;
     gap: var(--space-m);
-    padding-block: var(--space-2xs);
-    min-height: 4.25rem;
+    padding-block: var(--space-xs);
+    min-height: 4.5rem;
   }
 
   .brand {
     display: flex;
     align-items: center;
-    gap: var(--space-2xs);
     text-decoration: none;
     margin-inline-end: auto;
   }
 
+  /* The wordmark is dark ink on transparent: give it a plate on dark themes. */
   .brand img {
-    width: 2.75rem;
+    width: 6.5rem;
     height: auto;
-    background: oklch(99% 0 0);
+    padding: 0.35rem 0.5rem;
     border-radius: var(--radius-s);
-    padding: 0.2rem;
-  }
-
-  .brand-text {
-    font-weight: 700;
-    font-size: var(--text-1);
-    color: var(--color-ink);
-    line-height: var(--leading-solid);
-    white-space: nowrap;
-  }
-
-  .brand-city {
-    color: var(--edition-accent);
+    background: light-dark(transparent, var(--color-logo-tile));
   }
 
   .nav {
     display: flex;
-    gap: 0.25rem;
+    gap: 0.35rem;
   }
 
   .nav-item {
-    padding: 0.45em 0.9em;
+    padding: 0.4em 0.75em;
     border-radius: var(--radius-full);
     color: var(--color-text);
     text-decoration: none;
-    font-weight: 400;
-    transition: background var(--transition);
+    font-size: var(--text--1);
+    transition:
+      background var(--transition),
+      color var(--transition);
   }
 
   .nav-item:hover {
     background: var(--color-surface-2);
+    color: var(--color-ink);
   }
 
   .nav-item--active {
-    background: var(--g-yellow-soft);
     color: var(--color-ink);
     font-weight: 700;
   }
@@ -230,29 +217,29 @@ const ticketsUrl = CURRENT_EDITION.ticketsUrl;
 
   .lang {
     display: flex;
-    gap: 0.35em;
-    font-size: var(--text--1);
+    align-items: center;
+    gap: 0.3em;
+    font-size: var(--text--2);
     color: var(--color-text-muted);
   }
 
   .lang-item {
     color: var(--color-text-muted);
     text-decoration: none;
-    padding: 0.2em 0.3em;
+    padding: 0.2em 0.25em;
+  }
+
+  .lang-item:hover {
+    color: var(--color-ink);
   }
 
   .lang-item--active {
     color: var(--color-ink);
     font-weight: 700;
-    text-decoration: underline;
-    text-decoration-color: var(--edition-accent);
-    text-decoration-thickness: 2px;
-    text-underline-offset: 0.25em;
   }
 
   .tickets {
-    font-size: var(--text--1);
-    padding: 0.5em 1.2em;
+    padding: 0.7em 1.35em;
   }
 
   /* ---- Mobile burger ---- */
@@ -269,7 +256,7 @@ const ticketsUrl = CURRENT_EDITION.ticketsUrl;
     place-items: center;
     width: 2.75rem;
     height: 2.75rem;
-    border-radius: var(--radius-s);
+    border-radius: var(--radius-full);
     border: 1px solid var(--color-border);
   }
 
@@ -280,7 +267,7 @@ const ticketsUrl = CURRENT_EDITION.ticketsUrl;
   .burger-lines {
     display: grid;
     gap: 5px;
-    width: 1.25rem;
+    width: 1.15rem;
   }
 
   .burger-lines i {
@@ -307,9 +294,9 @@ const ticketsUrl = CURRENT_EDITION.ticketsUrl;
   .burger-menu {
     position: absolute;
     inset-inline-end: 0;
-    top: calc(100% + 0.5rem);
+    top: calc(100% + 0.6rem);
     display: grid;
-    gap: 0.25rem;
+    gap: 0.2rem;
     min-width: 14rem;
     padding: var(--space-xs);
     background: var(--color-bg);
@@ -319,7 +306,7 @@ const ticketsUrl = CURRENT_EDITION.ticketsUrl;
   }
 
   .burger-item {
-    padding: 0.55em 0.9em;
+    padding: 0.6em 0.9em;
     border-radius: var(--radius-s);
     text-decoration: none;
     color: var(--color-text);
@@ -330,7 +317,6 @@ const ticketsUrl = CURRENT_EDITION.ticketsUrl;
   }
 
   .burger-item--active {
-    background: var(--g-yellow-soft);
     color: var(--color-ink);
     font-weight: 700;
   }
@@ -355,16 +341,8 @@ const ticketsUrl = CURRENT_EDITION.ticketsUrl;
       gap: var(--space-xs);
     }
 
-    .brand {
-      gap: 0.4rem;
-    }
-
     .brand img {
-      width: 2.25rem;
-    }
-
-    .brand-text {
-      font-size: var(--text-0);
+      width: 5.25rem;
     }
   }
 </style>

--- a/src/components/Icon.astro
+++ b/src/components/Icon.astro
@@ -6,7 +6,6 @@
 interface Props {
   name: keyof typeof icons;
   size?: number;
-  class?: string;
 }
 
 const icons = {
@@ -80,12 +79,11 @@ const icons = {
   },
 } as const;
 
-const { name, size = 24, class: className } = Astro.props;
+const { name, size = 24 }: Props = Astro.props;
 const icon = icons[name];
 ---
 
 <svg
-  class={className}
   width={size}
   height={size}
   viewBox={icon.viewBox}

--- a/src/components/PageHeader.astro
+++ b/src/components/PageHeader.astro
@@ -1,0 +1,49 @@
+---
+/**
+ * Header of an interior page: pastel badge, title, optional lead and slot
+ * for extra actions. Mirrors the centered rhythm of the home sections.
+ */
+interface Props {
+  title: string;
+  /** Small pill above the title, usually the edition or the section name. */
+  badge?: string;
+  lead?: string;
+  align?: "center" | "start";
+}
+
+const { title, badge, lead, align = "center" }: Props = Astro.props;
+---
+
+<header class:list={["page-header", `page-header--${align}`]}>
+  {badge && <p class="badge badge--accent">{badge}</p>}
+  <h1>{title}</h1>
+  {lead && <p class="lead">{lead}</p>}
+  <slot />
+</header>
+
+<style>
+  .page-header {
+    display: grid;
+    gap: var(--space-xs);
+    margin-bottom: var(--space-l);
+  }
+
+  .page-header--center {
+    justify-items: center;
+    text-align: center;
+  }
+
+  .page-header--start {
+    justify-items: start;
+  }
+
+  h1 {
+    font-size: var(--text-5);
+    max-width: 18ch;
+  }
+
+  .lead {
+    color: var(--color-text-muted);
+    max-width: 62ch;
+  }
+</style>

--- a/src/components/PartnerGrid.astro
+++ b/src/components/PartnerGrid.astro
@@ -7,7 +7,8 @@ import { Image } from "astro:assets";
 import { getCollection } from "astro:content";
 
 /**
- * Partner logos of an edition, grouped by sponsorship level.
+ * Partner logos of an edition, grouped by sponsorship level: centered tier
+ * label, then a row of white logo tiles that shrink as the tier does.
  * Cards link to the partner page when it has content, otherwise straight
  * to the partner website (with UTM), like the old site did.
  */
@@ -33,16 +34,17 @@ const groups = levels
   }))
   .filter((g) => g.partners.length > 0);
 
-const levelColor: Record<string, string> = {
-  main: "blue",
-  diamond: "blue",
-  gold: "yellow",
-  silver: "yellow",
-  tech: "green",
-  bronze: "red",
-  community: "green",
-  patrocini: "plain",
-  media: "plain",
+/** Tile size per tier: the top tiers get more room, in design order. */
+const tileSize: Record<string, string> = {
+  main: "lg",
+  diamond: "lg",
+  gold: "md",
+  silver: "md",
+  tech: "sm",
+  bronze: "sm",
+  community: "sm",
+  patrocini: "xs",
+  media: "xs",
 };
 ---
 
@@ -50,15 +52,11 @@ const levelColor: Record<string, string> = {
   {
     groups.map(({ level, partners }) => (
       <section class="level" aria-label={level.title}>
-        <h3
-          class:list={[
-            "level-title",
-            `level-title--${levelColor[level.code] ?? "plain"}`,
-          ]}
+        <h3 class="level-title">{level.title}</h3>
+        <ul
+          class:list={["row", `row--${tileSize[level.code] ?? "sm"}`]}
+          role="list"
         >
-          {level.title}
-        </h3>
-        <ul class="grid" role="list">
           {partners.map((partner) => {
             const logo = partnerLogo(year, partner.code);
             const href = withPage.has(partner.code)
@@ -68,21 +66,19 @@ const levelColor: Record<string, string> = {
             return (
               <li>
                 <a
-                  class="card partner"
+                  class="logo-tile partner"
                   href={href}
                   target={external ? "_blank" : undefined}
                   rel={external ? "noopener" : undefined}
                 >
-                  <span class="logo">
-                    {logo ? (
+                  {logo ? (
+                    <>
                       <Image src={logo} alt="" width="240" densities={[1, 2]} />
-                    ) : (
-                      <span class="logo-placeholder" aria-hidden="true">
-                        {partner.name.charAt(0)}
-                      </span>
-                    )}
-                  </span>
-                  <span class="name">{partner.name}</span>
+                      <span class="visually-hidden">{partner.name}</span>
+                    </>
+                  ) : (
+                    <span class="name">{partner.name}</span>
+                  )}
                 </a>
               </li>
             );
@@ -96,76 +92,62 @@ const levelColor: Record<string, string> = {
 <style>
   .partner-groups {
     display: grid;
-    gap: var(--space-l);
+    gap: var(--space-m);
   }
 
   .level-title {
-    display: inline-block;
-    font-size: var(--text-0);
-    padding: 0.2em 0.9em;
-    border-radius: var(--radius-full);
-    border: 1px solid var(--color-border);
-    margin-bottom: var(--space-s);
-    background: var(--color-surface);
+    font-size: var(--text--1);
+    text-align: center;
+    margin-bottom: var(--space-xs);
   }
 
-  .level-title--blue {
-    background: var(--g-blue-soft);
-  }
-
-  .level-title--yellow {
-    background: var(--g-yellow-soft);
-  }
-
-  .level-title--green {
-    background: var(--g-green-soft);
-  }
-
-  .level-title--red {
-    background: var(--g-red-soft);
-  }
-
-  .grid {
+  .row {
     list-style: none;
     padding: 0;
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
-    gap: var(--space-s);
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: var(--space-2xs);
   }
 
   .partner {
-    display: grid;
-    justify-items: center;
-    gap: var(--space-2xs);
-    text-align: center;
+    aspect-ratio: 1;
+    transition:
+      border-color var(--transition),
+      transform var(--transition);
   }
 
-  .logo {
-    display: grid;
-    place-items: center;
-    width: 100%;
-    aspect-ratio: 3 / 2;
-    background: oklch(99% 0 0);
-    border-radius: var(--radius-m);
-    padding: var(--space-2xs);
+  .partner:hover {
+    border-color: var(--color-border-strong);
+    transform: translateY(-2px);
   }
 
-  .logo img {
-    max-width: 85%;
-    max-height: 85%;
-    width: auto;
-    height: auto;
-    object-fit: contain;
+  .row--lg .partner {
+    width: 7.5rem;
   }
 
-  .logo-placeholder {
-    font-size: var(--text-4);
-    font-weight: 700;
-    color: oklch(60% 0.02 270);
+  .row--md .partner {
+    width: 6.5rem;
+  }
+
+  .row--sm .partner {
+    width: 5.5rem;
+  }
+
+  .row--xs .partner {
+    width: 5rem;
+  }
+
+  .partner img {
+    max-width: 84%;
+    max-height: 84%;
   }
 
   .name {
+    font-size: var(--text--2);
+    font-weight: 700;
     color: var(--color-text);
-    font-size: var(--text--1);
+    text-align: center;
+    line-height: 1.2;
   }
 </style>

--- a/src/components/PersonCard.astro
+++ b/src/components/PersonCard.astro
@@ -27,7 +27,7 @@ const Tag = href ? "a" : "div";
   <span class="photo">
     {
       image ? (
-        <Image src={image} alt="" width="200" height="200" densities={[1, 2]} />
+        <Image src={image} alt="" width="240" height="240" densities={[1, 2]} />
       ) : (
         <span class="placeholder" aria-hidden="true">
           {name.charAt(0)}
@@ -44,22 +44,22 @@ const Tag = href ? "a" : "div";
   .person {
     display: grid;
     justify-items: center;
-    gap: 0.15rem;
+    gap: 0.1rem;
     text-align: center;
-    padding: var(--space-s);
+    padding: var(--space-s) var(--space-xs) var(--space-m);
   }
 
   .photo {
-    margin-bottom: var(--space-2xs);
+    margin-bottom: var(--space-xs);
   }
 
   .photo img,
   .placeholder {
-    width: 7.5rem;
-    height: 7.5rem;
-    border-radius: 50%;
+    width: 100%;
+    max-width: 8rem;
+    aspect-ratio: 1;
+    border-radius: var(--radius-m);
     object-fit: cover;
-    border: 3px solid var(--edition-accent-soft);
   }
 
   .placeholder {
@@ -75,17 +75,17 @@ const Tag = href ? "a" : "div";
     font-weight: 700;
     color: var(--color-ink);
     line-height: var(--leading-title);
+    letter-spacing: var(--tracking-tight);
   }
 
   .meta {
     color: var(--color-text);
-    font-style: italic;
     font-size: var(--text--1);
   }
 
   .detail {
     color: var(--color-text-muted);
-    font-size: var(--text--1);
-    line-height: 1.35;
+    font-size: var(--text--2);
+    line-height: 1.4;
   }
 </style>

--- a/src/components/PromoCard.astro
+++ b/src/components/PromoCard.astro
@@ -1,0 +1,96 @@
+---
+import Decor from "@components/Decor.astro";
+
+/**
+ * White card with a pastel badge, a short pitch and a single action
+ * (call for speakers, "send your CV"…).
+ */
+interface Props {
+  badge: string;
+  title: string;
+  text: string;
+  action: { label: string; href: string; external?: boolean };
+  tone?: "green" | "blue" | "yellow" | "red";
+  /** Ornament floated over the top corner of the card. */
+  decor?: { shape: "cross" | "squares"; tone: "pink" | "yellow" | "blue" };
+  /** Heading level, so the card fits the surrounding outline. */
+  as?: "h2" | "h3";
+}
+
+const {
+  badge,
+  title,
+  text,
+  action,
+  tone = "green",
+  decor,
+  as: Tag = "h2",
+}: Props = Astro.props;
+---
+
+<div class="promo">
+  {
+    decor && (
+      <span class="promo-decor">
+        <Decor shape={decor.shape} tone={decor.tone} size={2.75} />
+      </span>
+    )
+  }
+  <div class="promo-body">
+    <p class:list={["badge", `badge--${tone}`]}>{badge}</p>
+    <Tag class="promo-title">{title}</Tag>
+    <p class="promo-text">{text}</p>
+  </div>
+  <a
+    class="button button--secondary"
+    href={action.href}
+    target={action.external ? "_blank" : undefined}
+    rel={action.external ? "noopener" : undefined}
+  >
+    {action.label}
+  </a>
+</div>
+
+<style>
+  .promo {
+    position: relative;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: center;
+    gap: var(--space-m);
+    padding: var(--space-m);
+    background: var(--color-card);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-m);
+  }
+
+  .promo-decor {
+    position: absolute;
+    top: 0;
+    inset-inline-end: var(--space-m);
+    translate: 0 -55%;
+  }
+
+  .promo-body {
+    display: grid;
+    justify-items: start;
+    gap: var(--space-3xs);
+  }
+
+  .promo-title {
+    font-size: var(--text-2);
+  }
+
+  .promo-text {
+    color: var(--color-text-muted);
+    font-size: var(--text--1);
+    max-width: 60ch;
+  }
+
+  @media (max-width: 47.9375em) {
+    .promo {
+      grid-template-columns: 1fr;
+      justify-items: start;
+    }
+  }
+</style>

--- a/src/components/SectionHeading.astro
+++ b/src/components/SectionHeading.astro
@@ -1,31 +1,45 @@
 ---
-/** Section heading with optional kicker and the four-color DevFest dots. */
+/** Heading of an in-page section, with an optional kicker and lead. */
 interface Props {
   title: string;
   kicker?: string;
+  lead?: string;
   /** Heading level, defaults to h2. */
-  as?: "h1" | "h2" | "h3";
+  as?: "h2" | "h3";
+  align?: "center" | "start";
   id?: string;
 }
 
-const { title, kicker, as: Tag = "h2", id } = Astro.props;
+const {
+  title,
+  kicker,
+  lead,
+  as: Tag = "h2",
+  align = "center",
+  id,
+}: Props = Astro.props;
 ---
 
-<div class="section-heading">
+<div class:list={["section-heading", `section-heading--${align}`]}>
   {kicker && <p class="kicker">{kicker}</p>}
   <Tag {id}>{title}</Tag>
-  <span class="four-dots" aria-hidden="true"><i></i><i></i></span>
+  {lead && <p class="lead">{lead}</p>}
 </div>
 
 <style>
   .section-heading {
     display: grid;
-    gap: var(--space-3xs);
+    gap: var(--space-2xs);
     margin-bottom: var(--space-m);
   }
 
-  h1 {
-    font-size: var(--text-4);
+  .section-heading--center {
+    justify-items: center;
+    text-align: center;
+  }
+
+  .section-heading--start {
+    justify-items: start;
   }
 
   h2 {
@@ -36,7 +50,8 @@ const { title, kicker, as: Tag = "h2", id } = Astro.props;
     font-size: var(--text-2);
   }
 
-  .four-dots {
-    margin-top: var(--space-2xs);
+  .lead {
+    color: var(--color-text-muted);
+    max-width: 62ch;
   }
 </style>

--- a/src/components/SessionList.astro
+++ b/src/components/SessionList.astro
@@ -60,56 +60,51 @@ function speakerLabel(session: Session): string {
               {fmtTime(session.data.starts, locale)}
             </time>
             <span class="time-end">{fmtTime(session.data.ends, locale)}</span>
-            <span class="chip chip--red now">{t("agenda.now")}</span>
+            <span class="badge badge--red now">{t("agenda.now")}</span>
           </p>
           <div class="body">
             <Heading class="title">
               <a href={l(`/${year}/sessions/${slugOf(session)}/`)}>
                 {session.data.title}
               </a>
+            </Heading>
+            <p class="tags">
               {session.data.workshop && (
-                <span class="chip chip--green">{t("agenda.workshop")}</span>
+                <span class="badge badge--green">{t("agenda.workshop")}</span>
               )}
               {session.data.lang === "en" && locale === "it" && (
-                <span class="chip chip--blue" title={t("session.lang.en")}>
+                <span class="badge badge--blue" title={t("session.lang.en")}>
                   EN
                 </span>
               )}
               {session.data.lang === "it" && locale === "en" && (
-                <span class="chip chip--blue" title={t("session.lang.it")}>
+                <span class="badge badge--blue" title={t("session.lang.it")}>
                   IT
                 </span>
               )}
-            </Heading>
+            </p>
             {(showRooms || showSpeakers) && (
               <p class="meta">
                 {showRooms && rooms.length > 0 && (
                   <span>
-                    {rooms.length === 1
-                      ? t("agenda.room")
-                      : t("agenda.rooms.simultaneous")}
-                    :{" "}
-                    {rooms.map((room, i) => (
-                      <>
-                        {i > 0 && ", "}
-                        <a href={l(`/${year}/rooms/${slugOf(room)}/`)}>
-                          {room.data.name}
-                        </a>
-                      </>
-                    ))}
+                    {`${rooms.length === 1 ? t("agenda.room") : t("agenda.rooms.simultaneous")}: `}
+                    <span class="inline-list">
+                      {rooms.map((room) => {
+                        const href = l(`/${year}/rooms/${slugOf(room)}/`);
+                        return <a {href}>{room.data.name}</a>;
+                      })}
+                    </span>
                   </span>
                 )}
                 {showSpeakers && speakers.length > 0 && (
                   <span>
-                    {speakerLabel(session)}:{" "}
-                    {speakers.map((speaker, i) => (
-                      <>
-                        {i > 0 && ", "}
-                        <a href={l(`/speakers/${speaker.id}/`)}>
-                          {speaker.data.name}
-                        </a>
-                      </>
-                    ))}
+                    {`${speakerLabel(session)}: `}
+                    <span class="inline-list">
+                      {speakers.map((speaker) => {
+                        const href = l(`/speakers/${speaker.id}/`);
+                        return <a {href}>{speaker.data.name}</a>;
+                      })}
+                    </span>
                   </span>
                 )}
               </p>
@@ -129,26 +124,27 @@ function speakerLabel(session: Session): string {
     list-style: none;
     padding: 0;
     display: grid;
+    gap: var(--space-2xs);
   }
 
   .session {
     display: grid;
-    grid-template-columns: 6.5rem 1fr;
+    grid-template-columns: 6rem 1fr;
     gap: var(--space-s);
-    padding-block: var(--space-s);
-    border-bottom: 1px solid var(--color-border);
-    transition: opacity var(--transition);
-  }
-
-  .session:last-child {
-    border-bottom: none;
+    padding: var(--space-s) var(--space-m);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-m);
+    background: var(--color-card);
+    transition:
+      opacity var(--transition),
+      border-color var(--transition);
   }
 
   .time {
     display: flex;
     flex-direction: column;
     align-items: flex-start;
-    gap: 0.15rem;
+    gap: 0.1rem;
     font-weight: 700;
     color: var(--color-ink);
     line-height: var(--leading-title);
@@ -170,11 +166,7 @@ function speakerLabel(session: Session): string {
   }
 
   .title {
-    font-size: var(--text-0);
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.5em;
+    font-size: var(--text-1);
   }
 
   .title a {
@@ -188,10 +180,24 @@ function speakerLabel(session: Session): string {
     text-decoration-thickness: 2px;
   }
 
+  .tags {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem;
+  }
+
+  .tags:empty {
+    display: none;
+  }
+
   .meta {
     color: var(--color-text-muted);
     font-size: var(--text--1);
-    margin-top: 0.25rem;
+    margin-top: 0.35rem;
+  }
+
+  .meta a {
+    color: inherit;
   }
 
   .meta > span:not(:first-child)::before {
@@ -201,7 +207,7 @@ function speakerLabel(session: Session): string {
   .warning {
     margin-top: 0.35rem;
     font-size: var(--text--1);
-    color: light-dark(oklch(45% 0.15 30), oklch(80% 0.12 40));
+    color: var(--g-red-ink);
   }
 
   /* States toggled by the agenda enhancement script */
@@ -210,10 +216,8 @@ function speakerLabel(session: Session): string {
   }
 
   :global(.session--current) {
+    border-color: var(--g-green);
     background: var(--g-green-soft);
-    border-radius: var(--radius-m);
-    padding-inline: var(--space-s);
-    border-bottom-color: transparent;
   }
 
   :global(.session--current) .now {
@@ -224,6 +228,7 @@ function speakerLabel(session: Session): string {
     .session {
       grid-template-columns: 1fr;
       gap: var(--space-3xs);
+      padding: var(--space-s);
     }
 
     .time {

--- a/src/components/Statistics.astro
+++ b/src/components/Statistics.astro
@@ -1,5 +1,4 @@
 ---
-import Icon from "@components/Icon.astro";
 import { useTranslations, type Locale } from "@i18n/index";
 import type { EditionStats } from "@lib/content";
 
@@ -12,29 +11,13 @@ const { stats, locale } = Astro.props;
 const t = useTranslations(locale);
 
 const items = [
+  { value: stats.rooms, label: t("home.stats.rooms"), color: "blue" },
+  { value: stats.speakers, label: t("home.stats.speakers"), color: "red" },
+  { value: stats.workshops, label: t("home.stats.workshops"), color: "yellow" },
   {
-    icon: "room",
-    value: stats.rooms,
-    label: t("home.stats.rooms"),
-    color: "red",
-  },
-  {
-    icon: "mic",
-    value: stats.speakers,
-    label: t("home.stats.speakers"),
-    color: "yellow",
-  },
-  {
-    icon: "workshop",
-    value: stats.workshops,
-    label: t("home.stats.workshops"),
-    color: "green",
-  },
-  {
-    icon: "people",
     value: stats.participants ? `${stats.participants}+` : undefined,
     label: t("home.stats.participants"),
-    color: "blue",
+    color: "green",
   },
 ] as const;
 ---
@@ -44,10 +27,10 @@ const items = [
     items
       .filter((i) => i.value !== undefined && i.value !== 0)
       .map((item) => (
-        <li class:list={["stat", `stat--${item.color}`]}>
-          <Icon name={item.icon} size={44} class="stat-icon" />
+        <li class="stat">
           <span class="stat-value">{item.value}</span>
           <span class="stat-label">{item.label}</span>
+          <span class:list={["stat-rule", `stat-rule--${item.color}`]} />
         </li>
       ))
   }
@@ -58,51 +41,54 @@ const items = [
     list-style: none;
     padding: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(10rem, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(9rem, 1fr));
     gap: var(--space-s);
   }
 
   .stat {
     display: grid;
     justify-items: center;
-    gap: 0.2rem;
+    gap: 0.15rem;
     padding: var(--space-m) var(--space-s);
-    border-radius: var(--radius-l);
+    border-radius: var(--radius-m);
     border: 1px solid var(--color-border);
+    background: var(--color-card);
     text-align: center;
   }
 
-  .stat--red {
-    background: var(--g-red-soft);
-    color: var(--g-red);
-  }
-
-  .stat--yellow {
-    background: var(--g-yellow-soft);
-    color: light-dark(oklch(60% 0.13 75), var(--g-yellow));
-  }
-
-  .stat--green {
-    background: var(--g-green-soft);
-    color: var(--g-green);
-  }
-
-  .stat--blue {
-    background: var(--g-blue-soft);
-    color: var(--g-blue);
-  }
-
   .stat-value {
-    font-size: var(--text-4);
+    font-size: var(--text-5);
     font-weight: 700;
     line-height: var(--leading-solid);
+    letter-spacing: var(--tracking-tight);
     color: var(--color-ink);
   }
 
   .stat-label {
     color: var(--color-text-muted);
     font-size: var(--text--1);
-    text-transform: uppercase;
-    letter-spacing: 0.08em;
+  }
+
+  .stat-rule {
+    width: 2.5rem;
+    height: 3px;
+    border-radius: var(--radius-full);
+    margin-top: var(--space-2xs);
+  }
+
+  .stat-rule--blue {
+    background: var(--g-blue);
+  }
+
+  .stat-rule--red {
+    background: var(--g-red);
+  }
+
+  .stat-rule--yellow {
+    background: var(--g-yellow);
+  }
+
+  .stat-rule--green {
+    background: var(--g-green);
   }
 </style>

--- a/src/components/pages/AgendaPage.astro
+++ b/src/components/pages/AgendaPage.astro
@@ -1,7 +1,7 @@
 ---
-import Callout from "@components/Callout.astro";
 import EditionNotice from "@components/EditionNotice.astro";
-import SectionHeading from "@components/SectionHeading.astro";
+import PageHeader from "@components/PageHeader.astro";
+import PromoCard from "@components/PromoCard.astro";
 import SessionList from "@components/SessionList.astro";
 import { editionOf, isCurrent } from "@configs/editions";
 import { localizePath, useTranslations, type Locale } from "@i18n/index";
@@ -15,7 +15,7 @@ import {
   groupByDay,
   slugOf,
 } from "@lib/content";
-import { fmtWeekdayDate } from "@lib/dates";
+import { daysRangeLabel, fmtWeekdayDate, sentenceCase } from "@lib/dates";
 import { render } from "astro:content";
 
 interface Props {
@@ -53,13 +53,19 @@ const IntroContent = intro ? (await render(intro)).Content : null;
   {year}
   noCtas={!current}
 >
-  <div class="container section">
+  <div
+    class="container container--inset section"
+    data-agenda-live={current ? "" : undefined}
+  >
     <EditionNotice {year} {locale} />
-    <SectionHeading as="h1" title={t("agenda.title", { year })} kicker="DevFest Modena" />
+    <PageHeader
+      title={t("agenda.title", { year })}
+      badge={daysRangeLabel(edition.data.days, locale)}
+    />
 
     {
       IntroContent && (
-        <div class="prose intro">
+        <div class="prose prose--center intro">
           <IntroContent />
         </div>
       )
@@ -67,14 +73,15 @@ const IntroContent = intro ? (await render(intro)).Content : null;
 
     {
       cfs?.open && (
-        <Callout variant="info">
-          <p>{t("cfs.text", { year })}</p>
-          <p>
-            <a class="button" href={cfs.url} target="_blank" rel="noopener">
-              {t("cfs.button")}
-            </a>
-          </p>
-        </Callout>
+        <div class="cfs">
+          <PromoCard
+            badge={t("cfs.badge")}
+            title={t("cfs.title")}
+            text={t("cfs.text", { year })}
+            action={{ label: t("cfs.button"), href: cfs.url, external: true }}
+            decor={{ shape: "cross", tone: "pink" }}
+          />
+        </div>
       )
     }
 
@@ -83,7 +90,7 @@ const IntroContent = intro ? (await render(intro)).Content : null;
         <nav class="day-nav" aria-label={t("agenda.day")}>
           {days.map((day) => (
             <a class="chip" href={`#day-${day.key}`}>
-              {fmtWeekdayDate(day.date, locale)}
+              {sentenceCase(fmtWeekdayDate(day.date, locale))}
             </a>
           ))}
         </nav>
@@ -94,7 +101,7 @@ const IntroContent = intro ? (await render(intro)).Content : null;
       days.map((day) => (
         <section class="day" aria-labelledby={`day-${day.key}`}>
           <h2 class="day-title" id={`day-${day.key}`}>
-            {fmtWeekdayDate(day.date, locale)}
+            {sentenceCase(fmtWeekdayDate(day.date, locale))}
           </h2>
           <SessionList
             sessions={day.sessions}
@@ -107,79 +114,75 @@ const IntroContent = intro ? (await render(intro)).Content : null;
       ))
     }
 
-    <section class="rooms">
-      <h2>{t("agenda.rooms.sessions")}</h2>
-      <ul>
-        {
-          sessionRooms.map((room) => (
-            <li>
-              <a href={l(`/${year}/rooms/${slugOf(room)}/`)}>
-                <strong>{room.data.name}</strong>
-              </a>
-              {room.data.summary && <>: {room.data.summary}</>}
-            </li>
-          ))
-        }
-      </ul>
-      {
-        otherRooms.length > 0 && (
-          <>
-            <h2>{t("agenda.rooms.other")}</h2>
-            <ul>
-              {otherRooms.map((room) => (
+    {
+      [
+        { title: t("agenda.rooms.sessions"), items: sessionRooms },
+        { title: t("agenda.rooms.other"), items: otherRooms },
+      ]
+        .filter((group) => group.items.length > 0)
+        .map((group) => (
+          <section class="rooms">
+            <h2>{group.title}</h2>
+            <ul role="list">
+              {group.items.map((room) => (
                 <li>
-                  <a href={l(`/${year}/rooms/${slugOf(room)}/`)}>
-                    <strong>{room.data.name}</strong>
+                  <a
+                    class="card room"
+                    href={l(`/${year}/rooms/${slugOf(room)}/`)}
+                  >
+                    <span class="room-name">{room.data.name}</span>
+                    {room.data.summary && (
+                      <span class="room-summary">{room.data.summary}</span>
+                    )}
                   </a>
-                  {room.data.summary && <>: {room.data.summary}</>}
                 </li>
               ))}
             </ul>
-          </>
-        )
-      }
-    </section>
+          </section>
+        ))
+    }
   </div>
 
-  {
-    current && (
-      <script>
-        // Progressive enhancement: highlight sessions happening right now,
-        // fade the ones already over. Works only while the event is running.
-        const OFFSET = 15 * 60 * 1000; // highlight 15 minutes early
-        function refresh() {
-          const now = Date.now();
-          let any = false;
-          document.querySelectorAll<HTMLElement>(".session[data-starts]").forEach((el) => {
-            const starts = Date.parse(el.dataset.starts ?? "") - OFFSET;
-            const ends = Date.parse(el.dataset.ends ?? "");
-            if (Number.isNaN(starts) || Number.isNaN(ends)) return;
-            el.classList.toggle("session--current", now >= starts && now < ends);
-            el.classList.toggle("session--past", now >= ends);
-            any = true;
-          });
-          if (any) setTimeout(refresh, 60 * 1000);
+  <script>
+    // Progressive enhancement: highlight the sessions happening right now and
+    // fade the ones already over. Only the current edition opts in, via the
+    // data-agenda-live flag on the page wrapper.
+    if (document.querySelector("[data-agenda-live]")) {
+      const OFFSET = 15 * 60 * 1000; // highlight 15 minutes early
+      const refresh = () => {
+        const now = Date.now();
+        let any = false;
+        for (const el of document.querySelectorAll(".session[data-starts]")) {
+          if (!(el instanceof HTMLElement)) continue;
+          const starts = Date.parse(el.dataset.starts ?? "") - OFFSET;
+          const ends = Date.parse(el.dataset.ends ?? "");
+          if (Number.isNaN(starts) || Number.isNaN(ends)) continue;
+          el.classList.toggle("session--current", now >= starts && now < ends);
+          el.classList.toggle("session--past", now >= ends);
+          any = true;
         }
-        refresh();
-      </script>
-    )
-  }
+        if (any) setTimeout(refresh, 60 * 1000);
+      };
+      refresh();
+    }
+  </script>
 </BaseLayout>
 
 <style>
   .intro {
-    margin-bottom: var(--space-m);
+    margin-bottom: var(--space-l);
+  }
+
+  .cfs {
+    margin-bottom: var(--space-l);
   }
 
   .day-nav {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
     gap: var(--space-2xs);
-    margin-bottom: var(--space-m);
-  }
-
-  .day-nav .chip {
-    text-transform: capitalize;
+    margin-bottom: var(--space-l);
   }
 
   .day {
@@ -188,31 +191,38 @@ const IntroContent = intro ? (await render(intro)).Content : null;
 
   .day-title {
     font-size: var(--text-2);
-    text-transform: capitalize;
-    padding-bottom: var(--space-2xs);
-    border-bottom: 3px solid var(--edition-accent);
-    margin-bottom: var(--space-2xs);
+    margin-bottom: var(--space-s);
   }
 
   .rooms {
-    margin-top: var(--space-xl);
+    margin-top: var(--space-l);
   }
 
   .rooms h2 {
     font-size: var(--text-1);
-    margin-bottom: var(--space-2xs);
-    margin-top: var(--space-m);
+    margin-bottom: var(--space-xs);
   }
 
   .rooms ul {
-    padding-inline-start: 1.2em;
+    list-style: none;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(14rem, 1fr));
+    gap: var(--space-2xs);
   }
 
-  .rooms li {
-    margin-block: 0.3em;
+  .room {
+    display: grid;
+    gap: 0.1rem;
   }
 
-  .rooms li::marker {
-    color: var(--edition-accent);
+  .room-name {
+    font-weight: 700;
+    color: var(--color-ink);
+  }
+
+  .room-summary {
+    color: var(--color-text-muted);
+    font-size: var(--text--1);
   }
 </style>

--- a/src/components/pages/ArchivePage.astro
+++ b/src/components/pages/ArchivePage.astro
@@ -1,10 +1,10 @@
 ---
-import SectionHeading from "@components/SectionHeading.astro";
+import PageHeader from "@components/PageHeader.astro";
 import { ARCHIVED_YEARS } from "@configs/editions";
 import { localizePath, useTranslations, type Locale } from "@i18n/index";
 import BaseLayout from "@layouts/BaseLayout.astro";
 import { getEdition, getStats } from "@lib/content";
-import { daysRangeLabel } from "@lib/dates";
+import { daysRangeLabel, sentenceCase } from "@lib/dates";
 
 interface Props {
   locale: Locale;
@@ -23,13 +23,12 @@ const editions = await Promise.all(
 ---
 
 <BaseLayout title={t("archive.title")} {locale}>
-  <div class="container section">
-    <SectionHeading
-      as="h1"
+  <div class="container container--narrow section">
+    <PageHeader
       title={t("archive.title")}
-      kicker="DevFest Modena"
+      badge="DevFest Modena"
+      lead={t("archive.intro")}
     />
-    <p class="lead">{t("archive.intro")}</p>
 
     <ul class="list" role="list">
       {
@@ -38,21 +37,21 @@ const editions = await Promise.all(
             <a class="card edition" href={localizePath(locale, `/${year}/`)}>
               <span class="year">{year}</span>
               <span class="date">
-                {daysRangeLabel(edition.data.days, locale)}
+                {sentenceCase(daysRangeLabel(edition.data.days, locale))}
               </span>
               <span class="stats">
                 {stats.speakers > 0 && (
-                  <span class="chip chip--yellow">
+                  <span class="badge badge--yellow">
                     {stats.speakers} {t("home.stats.speakers").toLowerCase()}
                   </span>
                 )}
                 {stats.rooms > 0 && (
-                  <span class="chip chip--red">
+                  <span class="badge badge--red">
                     {stats.rooms} {t("home.stats.rooms").toLowerCase()}
                   </span>
                 )}
                 {(stats.participants ?? 0) > 0 && (
-                  <span class="chip chip--blue">
+                  <span class="badge badge--blue">
                     {stats.participants}+{" "}
                     {t("home.stats.participants").toLowerCase()}
                   </span>
@@ -68,17 +67,11 @@ const editions = await Promise.all(
 </BaseLayout>
 
 <style>
-  .lead {
-    margin-block: calc(-1 * var(--space-xs)) var(--space-m);
-    color: var(--color-text-muted);
-  }
-
   .list {
     list-style: none;
     padding: 0;
     display: grid;
     gap: var(--space-s);
-    max-width: var(--container-narrow);
   }
 
   .edition {
@@ -90,12 +83,14 @@ const editions = await Promise.all(
     align-items: center;
     column-gap: var(--space-m);
     row-gap: var(--space-2xs);
+    padding: var(--space-s) var(--space-m);
   }
 
   .year {
     grid-area: year;
     font-size: var(--text-4);
     font-weight: 700;
+    letter-spacing: var(--tracking-tight);
     color: var(--edition-accent);
     line-height: var(--leading-solid);
   }
@@ -104,7 +99,6 @@ const editions = await Promise.all(
     grid-area: date;
     font-weight: 700;
     color: var(--color-ink);
-    text-transform: capitalize;
   }
 
   .stats {

--- a/src/components/pages/CommunitiesPage.astro
+++ b/src/components/pages/CommunitiesPage.astro
@@ -1,7 +1,7 @@
 ---
 import CommunitiesGrid from "@components/CommunitiesGrid.astro";
 import EditionNotice from "@components/EditionNotice.astro";
-import SectionHeading from "@components/SectionHeading.astro";
+import PageHeader from "@components/PageHeader.astro";
 import { isCurrent } from "@configs/editions";
 import { useTranslations, type Locale } from "@i18n/index";
 import BaseLayout from "@layouts/BaseLayout.astro";
@@ -27,17 +27,16 @@ const IntroContent = intro ? (await render(intro)).Content : null;
   {year}
   noCtas={!isCurrent(year)}
 >
-  <div class="container section">
+  <div class="container container--inset section">
     <EditionNotice {year} {locale} />
-    <SectionHeading
-      as="h1"
+    <PageHeader
       title={t("communities.title")}
-      kicker={`DevFest Modena ${year}`}
+      badge={`DevFest Modena ${year}`}
     />
 
     {
       IntroContent && (
-        <div class="prose intro">
+        <div class="prose prose--center intro">
           <IntroContent />
         </div>
       )
@@ -49,6 +48,6 @@ const IntroContent = intro ? (await render(intro)).Content : null;
 
 <style>
   .intro {
-    margin-bottom: var(--space-m);
+    margin-bottom: var(--space-l);
   }
 </style>

--- a/src/components/pages/EditionHubPage.astro
+++ b/src/components/pages/EditionHubPage.astro
@@ -1,5 +1,6 @@
 ---
 import EditionNotice from "@components/EditionNotice.astro";
+import PageHeader from "@components/PageHeader.astro";
 import PartnerGrid from "@components/PartnerGrid.astro";
 import SectionHeading from "@components/SectionHeading.astro";
 import Statistics from "@components/Statistics.astro";
@@ -79,12 +80,11 @@ const hasStats = stats.rooms > 0 || stats.speakers > 0 || stats.workshops > 0;
   {year}
   noCtas={!isCurrent(year)}
 >
-  <div class="container section">
+  <div class="container container--inset section">
     <EditionNotice {year} {locale} />
-    <SectionHeading
-      as="h1"
+    <PageHeader
       title={`DevFest Modena ${year}`}
-      kicker={daysRangeLabel(edition.data.days, locale)}
+      badge={daysRangeLabel(edition.data.days, locale)}
     />
 
     <ul class="links" role="list">
@@ -105,8 +105,8 @@ const hasStats = stats.rooms > 0 || stats.speakers > 0 || stats.workshops > 0;
 
     {
       hasStats && (
-        <section class="stats">
-          <h2>{t("home.stats.title", { year })}</h2>
+        <section class="block">
+          <SectionHeading title={t("home.stats.title", { year })} />
           <Statistics {stats} {locale} />
         </section>
       )
@@ -114,8 +114,8 @@ const hasStats = stats.rooms > 0 || stats.speakers > 0 || stats.workshops > 0;
 
     {
       edition.data.partners.length > 0 && (
-        <section class="partners">
-          <h2>{t("partners.title")}</h2>
+        <section class="block">
+          <SectionHeading title={t("partners.title")} />
           <PartnerGrid {year} {locale} />
         </section>
       )
@@ -137,9 +137,12 @@ const hasStats = stats.rooms > 0 || stats.speakers > 0 || stats.workshops > 0;
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: var(--space-s);
     font-weight: 700;
     color: var(--color-ink);
     font-size: var(--text-1);
+    border-color: transparent;
+    padding: var(--space-s) var(--space-m);
   }
 
   .link-card--blue {
@@ -158,14 +161,7 @@ const hasStats = stats.rooms > 0 || stats.speakers > 0 || stats.workshops > 0;
     background: var(--g-red-soft);
   }
 
-  .stats,
-  .partners {
+  .block {
     margin-top: var(--space-xl);
-  }
-
-  .stats h2,
-  .partners h2 {
-    font-size: var(--text-2);
-    margin-bottom: var(--space-s);
   }
 </style>

--- a/src/components/pages/FaqPage.astro
+++ b/src/components/pages/FaqPage.astro
@@ -1,5 +1,5 @@
 ---
-import SectionHeading from "@components/SectionHeading.astro";
+import PageHeader from "@components/PageHeader.astro";
 import { CURRENT_YEAR } from "@configs/editions";
 import { useTranslations, type Locale } from "@i18n/index";
 import BaseLayout from "@layouts/BaseLayout.astro";
@@ -38,13 +38,12 @@ const jsonLd = [
 ---
 
 <BaseLayout title={`${t("faq.title")} ${CURRENT_YEAR}`} {locale} {jsonLd}>
-  <div class="container section">
-    <SectionHeading
-      as="h1"
-      title={`${t("faq.title")} ${CURRENT_YEAR}`}
-      kicker="FAQ"
+  <div class="container container--narrow section">
+    <PageHeader
+      title={t("faq.title")}
+      badge={`DevFest Modena ${CURRENT_YEAR}`}
+      lead={t("faq.intro")}
     />
-    <p class="lead">{t("faq.intro")}</p>
 
     <div class="faq">
       {
@@ -60,34 +59,27 @@ const jsonLd = [
 </BaseLayout>
 
 <style>
-  .lead {
-    margin-block: calc(-1 * var(--space-xs)) var(--space-m);
-    color: var(--color-text-muted);
-  }
-
   .faq {
     display: grid;
     gap: var(--space-2xs);
-    max-width: var(--container-narrow);
   }
 
   .item {
     border: 1px solid var(--color-border);
     border-radius: var(--radius-m);
-    background: var(--color-surface);
+    background: var(--color-card);
     transition: border-color var(--transition);
   }
 
   .item[open] {
-    border-color: var(--edition-accent);
-    background: var(--color-bg);
+    border-color: var(--color-border-strong);
   }
 
   summary {
     cursor: pointer;
     font-weight: 700;
     color: var(--color-ink);
-    padding: var(--space-s);
+    padding: var(--space-s) var(--space-m);
     list-style: none;
     display: flex;
     justify-content: space-between;
@@ -104,11 +96,11 @@ const jsonLd = [
     flex-shrink: 0;
     display: grid;
     place-items: center;
-    width: 1.6em;
-    height: 1.6em;
+    width: 1.7em;
+    height: 1.7em;
     border-radius: 50%;
     background: var(--edition-accent-soft);
-    color: var(--color-ink);
+    color: var(--edition-accent-ink);
     font-weight: 400;
     transition: rotate var(--transition);
   }
@@ -118,7 +110,8 @@ const jsonLd = [
   }
 
   .answer {
-    padding: 0 var(--space-s) var(--space-s);
+    padding: 0 var(--space-m) var(--space-s);
+    font-size: var(--text--1);
   }
 
   .answer :global(p:first-child) {

--- a/src/components/pages/HomePage.astro
+++ b/src/components/pages/HomePage.astro
@@ -1,9 +1,16 @@
 ---
+import galleryOutside1 from "@assets/gallery/outisde-1.jpeg";
+import galleryOutside2 from "@assets/gallery/outisde-2.jpeg";
+import galleryPeople from "@assets/gallery/people.jpg";
+import galleryRuby from "@assets/gallery/ruby.jpg";
+import galleryNetworking from "@assets/gallery/sp_networking.jpg";
+import galleryTheater from "@assets/gallery/theater.jpg";
 import heroImage from "@assets/images/home-hero.webp";
-import logoHorizontal from "@assets/images/logo-horizontal-year.png";
-import Callout from "@components/Callout.astro";
 import CommunitiesGrid from "@components/CommunitiesGrid.astro";
+import Decor from "@components/Decor.astro";
+import Gallery from "@components/Gallery.astro";
 import PartnerGrid from "@components/PartnerGrid.astro";
+import PromoCard from "@components/PromoCard.astro";
 import SectionHeading from "@components/SectionHeading.astro";
 import Statistics from "@components/Statistics.astro";
 import {
@@ -16,7 +23,6 @@ import { localizePath, useTranslations, type Locale } from "@i18n/index";
 import BaseLayout from "@layouts/BaseLayout.astro";
 import { getEdition, getPage, getStats } from "@lib/content";
 import { daysRangeLabel } from "@lib/dates";
-import { Image, Picture } from "astro:assets";
 import { render } from "astro:content";
 
 interface Props {
@@ -35,6 +41,15 @@ const IntroContent = intro ? (await render(intro)).Content : null;
 
 const cfs = CURRENT_EDITION.callForSpeakers;
 const dateLabel = daysRangeLabel(edition.data.days, locale);
+
+const photos = [
+  { image: galleryNetworking, alt: "" },
+  { image: galleryTheater, alt: "" },
+  { image: galleryOutside1, alt: "" },
+  { image: galleryPeople, alt: "" },
+  { image: galleryRuby, alt: "" },
+  { image: galleryOutside2, alt: "" },
+];
 
 const jsonLd = [
   {
@@ -77,115 +92,97 @@ const jsonLd = [
   year={CURRENT_YEAR}
   {jsonLd}
 >
-  <section class="hero">
-    <Picture
-      class="hero-bg"
-      src={heroImage}
-      alt=""
-      widths={[480, 900, 1440, 1920]}
-      sizes="100vw"
-      formats={["avif"]}
-      fallbackFormat="webp"
-      loading="eager"
-      fetchpriority="high"
-    />
-    <div class="hero-scrim" aria-hidden="true"></div>
-    <div class="hero-content container">
-      <span class="hero-logo">
-        <Image
-          src={logoHorizontal}
-          alt={`${SITE_NAME} ${CURRENT_YEAR}`}
-          height={92}
-          densities={[1, 2]}
-          loading="eager"
-        />
+  <section class="hero container" aria-labelledby="hero-title">
+    <p class="hero-tag">
+      <Decor shape="arrow" tone="yellow" size={2.75} />
+      <span class="badge badge--accent">
+        {dateLabel}
+        <span aria-hidden="true">—</span>
+        <a href={l("/location/")}>{t("nav.location")}</a>
       </span>
-      <h1 class="hero-title">{dateLabel}</h1>
-      <p class="hero-claim">{t("home.claim")}</p>
-      <p class="hero-meta">
-        <span class="chip chip--yellow">{t("home.free")}</span>
-        <a
-          class="chip hero-venue"
-          href={CURRENT_EDITION.venue.mapsUrl}
-          target="_blank"
-          rel="noopener"
-        >
-          📍 {CURRENT_EDITION.venue.name}
-        </a>
-      </p>
-      <p class="hero-actions">
-        {
-          CURRENT_EDITION.ticketsUrl && (
-            <a
-              class="button"
-              href={CURRENT_EDITION.ticketsUrl}
-              target="_blank"
-              rel="noopener"
-            >
-              {t("home.hero.tickets")}
-            </a>
-          )
-        }
-        <a class="button button--light" href={l(`/${CURRENT_YEAR}/sessions/`)}>
-          {t("home.hero.agenda")}
-        </a>
-      </p>
+    </p>
+
+    <h1 class="hero-title" id="hero-title">DevFest <span>Modena</span></h1>
+
+    <div class="hero-lead">
+      <p>{t("home.claim")}</p>
+      {
+        CURRENT_EDITION.ticketsUrl && (
+          <a
+            class="button"
+            href={CURRENT_EDITION.ticketsUrl}
+            target="_blank"
+            rel="noopener"
+          >
+            {t("home.hero.tickets")}
+          </a>
+        )
+      }
     </div>
   </section>
 
   {
     IntroContent && (
-      <section class="section container">
-        <div class="prose intro">
-          <IntroContent />
-        </div>
-      </section>
+      <div class="container">
+        <section class="panel panel--center intro">
+          <div class="prose prose--center">
+            <IntroContent />
+          </div>
+          <a
+            class="button button--secondary"
+            href={l(`/${CURRENT_YEAR}/sessions/`)}
+          >
+            {t("home.intro.cta")}
+          </a>
+          <span class="dot-divider" aria-hidden="true">
+            <i />
+            <i />
+            <i />
+            <i />
+          </span>
+        </section>
+      </div>
     )
   }
+
+  <div class="section--tight container">
+    <Gallery {photos} label={t("home.gallery")} />
+  </div>
 
   {
     cfs?.open && (
-      <section class="section--tight container">
-        <Callout variant="info">
-          <h2>{t("cfs.title")}</h2>
-          <p>{t("cfs.text", { year: CURRENT_YEAR })}</p>
-          <p>
-            <a class="button" href={cfs.url} target="_blank" rel="noopener">
-              {t("cfs.button")}
-            </a>
-          </p>
-        </Callout>
+      <section class="section--tight container container--inset">
+        <PromoCard
+          badge={t("cfs.badge")}
+          title={t("cfs.title")}
+          text={t("cfs.text", { year: CURRENT_YEAR })}
+          action={{ label: t("cfs.button"), href: cfs.url, external: true }}
+          decor={{ shape: "cross", tone: "pink" }}
+        />
       </section>
     )
   }
 
-  <section class="section container">
-    <SectionHeading
-      title={t("home.stats.title", { year: statsYear })}
-      kicker="DevFest"
-    />
+  <section class="section container container--inset">
+    <SectionHeading title={t("home.stats.title", { year: statsYear })} />
     <Statistics {stats} {locale} />
   </section>
 
   <section class="section container">
-    <SectionHeading
-      title={t("home.communities.title")}
-      kicker={t("nav.communities")}
-    />
-    <p class="section-lead">{t("home.communities.text")}</p>
-    <CommunitiesGrid year={CURRENT_YEAR} codes={edition.data.communities} />
-  </section>
-
-  <section class="section container">
-    <SectionHeading title={t("partners.title")} kicker="Sponsor" />
+    <SectionHeading title={t("partners.title")} />
     <PartnerGrid year={CURRENT_YEAR} {locale} />
   </section>
 
-  <section class="section container">
+  <section class="section container container--inset">
     <SectionHeading
-      title={t("home.editions.title")}
-      kicker={t("nav.archive")}
+      title={t("home.communities.title")}
+      lead={t("home.communities.text")}
     />
+    <CommunitiesGrid year={CURRENT_YEAR} codes={edition.data.communities} />
+  </section>
+
+  <section class="section container container--inset">
+    <SectionHeading title={t("home.editions.title")} />
     <ul class="editions" role="list">
       {
         ARCHIVED_YEARS.map((y) => (
@@ -203,112 +200,103 @@ const jsonLd = [
 </BaseLayout>
 
 <style>
+  /* ---- Hero ---- */
+
   .hero {
-    position: relative;
-    min-height: min(82vh, 46rem);
     display: grid;
+    grid-template-columns: 1fr minmax(0, 24rem);
+    grid-template-areas:
+      "tag lead"
+      "title lead";
+    align-items: start;
+    column-gap: var(--space-l);
+    padding-block: var(--space-l) var(--space-2xl);
+  }
+
+  .hero-tag {
+    grid-area: tag;
+    display: flex;
     align-items: center;
-    overflow: hidden;
-  }
-
-  .hero :global(.hero-bg) {
-    position: absolute;
-    inset: 0;
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-  }
-
-  .hero-scrim {
-    position: absolute;
-    inset: 0;
-    background:
-      linear-gradient(
-        180deg,
-        oklch(15% 0.02 270 / 0.55),
-        oklch(15% 0.02 270 / 0.25) 45%,
-        oklch(15% 0.02 270 / 0.7)
-      ),
-      oklch(20% 0.02 270 / 0.2);
-  }
-
-  .hero-content {
-    position: relative;
-    display: grid;
-    justify-items: center;
-    text-align: center;
     gap: var(--space-s);
-    padding-block: var(--space-2xl);
+    margin-bottom: var(--space-s);
   }
 
-  .hero-logo {
-    background: oklch(99% 0 0);
-    border-radius: var(--radius-l);
-    padding: var(--space-xs) var(--space-m);
-    box-shadow: var(--shadow-2);
+  .hero-tag .badge {
+    font-size: var(--text--1);
+    padding: 0.5em 1.1em;
+    gap: 0.5em;
   }
 
-  .hero-logo img {
-    height: clamp(3.2rem, 8vi, 5.75rem);
-    width: auto;
+  .hero-tag a {
+    color: inherit;
   }
 
   .hero-title {
-    color: oklch(99% 0 0);
-    font-size: var(--text-5);
+    grid-area: title;
+    font-size: var(--text-display);
     line-height: var(--leading-solid);
-    text-shadow: 0 2px 24px oklch(0% 0 0 / 0.4);
+    letter-spacing: -0.035em;
   }
 
-  .hero-claim {
-    color: oklch(96% 0.005 90);
-    font-size: var(--text-1);
-    max-width: 34ch;
-    text-shadow: 0 1px 12px oklch(0% 0 0 / 0.5);
+  /* "Modena" always sits on its own line, without breaking the a11y name. */
+  .hero-title span {
+    display: block;
   }
 
-  .hero-meta {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: var(--space-2xs);
+  .hero-lead {
+    grid-area: lead;
+    display: grid;
+    justify-items: start;
+    gap: var(--space-s);
+    font-size: var(--text--1);
+    color: var(--color-text);
   }
 
-  .hero-venue {
-    background: oklch(99% 0 0 / 0.92);
-    color: oklch(24% 0.004 270);
-    border-color: transparent;
+  @media (max-width: 63.9375em) {
+    .hero {
+      grid-template-columns: 1fr;
+      grid-template-areas:
+        "tag"
+        "title"
+        "lead";
+      row-gap: var(--space-m);
+      padding-block: var(--space-m) var(--space-xl);
+    }
+
+    .hero-lead p {
+      max-width: 46ch;
+    }
   }
 
-  .hero-actions {
-    display: flex;
-    flex-wrap: wrap;
-    justify-content: center;
-    gap: var(--space-xs);
-    margin-top: var(--space-2xs);
-  }
+  /* ---- Intro panel ---- */
 
   .intro :global(h2) {
     font-size: var(--text-3);
+    margin-top: 0;
   }
 
-  .section-lead {
-    margin-block: calc(-1 * var(--space-xs)) var(--space-s);
-    color: var(--color-text-muted);
-    max-width: 60ch;
+  .intro .button {
+    margin-top: var(--space-s);
   }
+
+  .intro .dot-divider {
+    margin-top: var(--space-l);
+  }
+
+  /* ---- Previous editions ---- */
 
   .editions {
     list-style: none;
     padding: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
     gap: var(--space-s);
   }
 
   .edition-card {
     display: grid;
-    gap: 0.15rem;
+    gap: 0.1rem;
+    padding: var(--space-m) var(--space-s);
   }
 
   .edition-year {
@@ -316,6 +304,7 @@ const jsonLd = [
     font-weight: 700;
     color: var(--edition-accent);
     line-height: var(--leading-solid);
+    letter-spacing: var(--tracking-tight);
   }
 
   .edition-name {

--- a/src/components/pages/LocationPage.astro
+++ b/src/components/pages/LocationPage.astro
@@ -2,7 +2,7 @@
 import mapImage from "@assets/location/location.png";
 import Callout from "@components/Callout.astro";
 import Icon from "@components/Icon.astro";
-import SectionHeading from "@components/SectionHeading.astro";
+import PageHeader from "@components/PageHeader.astro";
 import { useTranslations, type Locale } from "@i18n/index";
 import BaseLayout from "@layouts/BaseLayout.astro";
 import { Image } from "astro:assets";
@@ -43,11 +43,7 @@ const sections = [
 
 <BaseLayout title={t("location.title")} {locale}>
   <div class="container section">
-    <SectionHeading
-      as="h1"
-      title={t("location.title")}
-      kicker={loc.introduction.title}
-    />
+    <PageHeader title={t("location.title")} badge={loc.introduction.title} />
 
     <nav class="page-nav" aria-label={t("location.nav.label")}>
       {
@@ -222,8 +218,9 @@ const sections = [
   .page-nav {
     display: flex;
     flex-wrap: wrap;
+    justify-content: center;
     gap: var(--space-2xs);
-    margin-bottom: var(--space-l);
+    margin-bottom: var(--space-xl);
   }
 
   .venue {
@@ -269,7 +266,7 @@ const sections = [
   }
 
   .venue-map img {
-    border-radius: var(--radius-m);
+    border-radius: var(--radius-s);
     width: 100%;
     height: auto;
   }
@@ -289,11 +286,10 @@ const sections = [
   }
 
   .photos :global(.photo) {
-    border-radius: var(--radius-l);
+    border-radius: var(--radius-m);
     width: 100%;
-    height: 100%;
+    aspect-ratio: 3 / 2;
     object-fit: cover;
-    border: 1px solid var(--color-border);
   }
 
   .block {
@@ -303,6 +299,7 @@ const sections = [
   .block h2 {
     font-size: var(--text-2);
     margin-bottom: var(--space-s);
+    text-align: center;
   }
 
   .cards {

--- a/src/components/pages/MarkdownPage.astro
+++ b/src/components/pages/MarkdownPage.astro
@@ -1,5 +1,5 @@
 ---
-import SectionHeading from "@components/SectionHeading.astro";
+import PageHeader from "@components/PageHeader.astro";
 import { defaultLocale, useTranslations, type Locale } from "@i18n/index";
 import BaseLayout from "@layouts/BaseLayout.astro";
 import { getPage } from "@lib/content";
@@ -11,10 +11,10 @@ interface Props {
   locale: Locale;
   /** Override the page title (defaults to the frontmatter title). */
   title?: string;
-  kicker?: string;
+  badge?: string;
 }
 
-const { slug, locale, title, kicker = "DevFest Modena" } = Astro.props;
+const { slug, locale, title, badge = "DevFest Modena" } = Astro.props;
 const t = useTranslations(locale);
 
 const page = await getPage(locale, slug);
@@ -28,8 +28,8 @@ const pageTitle = title ?? page.data.title;
 ---
 
 <BaseLayout title={pageTitle} description={page.data.description} {locale}>
-  <div class="container section">
-    <SectionHeading as="h1" title={pageTitle} {kicker} />
+  <div class="container container--narrow section">
+    <PageHeader title={pageTitle} {badge} lead={page.data.description} />
     {fallback && <p class="fallback-note">{t("lang.only.it")}</p>}
     <div class="prose">
       <Content />
@@ -42,5 +42,6 @@ const pageTitle = title ?? page.data.title;
     color: var(--color-text-muted);
     font-style: italic;
     margin-bottom: var(--space-s);
+    text-align: center;
   }
 </style>

--- a/src/components/pages/PartnerPage.astro
+++ b/src/components/pages/PartnerPage.astro
@@ -42,7 +42,7 @@ const link = withUtm(partner.link, year);
     <div class="head">
       {
         logo && (
-          <span class="logo">
+          <span class="logo-tile logo">
             <Image
               src={logo}
               alt=""
@@ -55,7 +55,7 @@ const link = withUtm(partner.link, year);
       }
       <div>
         <h1>{partner.name}</h1>
-        {level && <p class="chip chip--yellow">{level.title}</p>}
+        {level && <p class="badge badge--yellow">{level.title}</p>}
         <p class="link">
           <a href={link} target="_blank" rel="noopener"
             >{partner.link.replace(/^https?:\/\//, "").replace(/\/$/, "")} ↗</a
@@ -103,22 +103,8 @@ const link = withUtm(partner.link, year);
   }
 
   .logo {
-    display: grid;
-    place-items: center;
-    width: 14rem;
-    aspect-ratio: 3 / 2;
-    background: oklch(99% 0 0);
-    border: 1px solid var(--color-border);
-    border-radius: var(--radius-l);
-    padding: var(--space-s);
-  }
-
-  .logo img {
-    max-width: 100%;
-    max-height: 100%;
-    width: auto;
-    height: auto;
-    object-fit: contain;
+    width: 12rem;
+    aspect-ratio: 1;
   }
 
   h1 {

--- a/src/components/pages/PartnersIndexPage.astro
+++ b/src/components/pages/PartnersIndexPage.astro
@@ -1,7 +1,7 @@
 ---
 import EditionNotice from "@components/EditionNotice.astro";
+import PageHeader from "@components/PageHeader.astro";
 import PartnerGrid from "@components/PartnerGrid.astro";
-import SectionHeading from "@components/SectionHeading.astro";
 import { isCurrent } from "@configs/editions";
 import { useTranslations, type Locale } from "@i18n/index";
 import BaseLayout from "@layouts/BaseLayout.astro";
@@ -23,20 +23,11 @@ const t = useTranslations(locale);
 >
   <div class="container section">
     <EditionNotice {year} {locale} />
-    <SectionHeading
-      as="h1"
+    <PageHeader
       title={t("partners.title")}
-      kicker={`DevFest Modena ${year}`}
+      badge={`DevFest Modena ${year}`}
+      lead={t("partners.intro")}
     />
-    <p class="lead">{t("partners.intro")}</p>
     <PartnerGrid {year} {locale} />
   </div>
 </BaseLayout>
-
-<style>
-  .lead {
-    margin-block: calc(-1 * var(--space-xs)) var(--space-m);
-    color: var(--color-text-muted);
-    max-width: 65ch;
-  }
-</style>

--- a/src/components/pages/RoomPage.astro
+++ b/src/components/pages/RoomPage.astro
@@ -13,7 +13,7 @@ import {
   slugOf,
   type Room,
 } from "@lib/content";
-import { fmtWeekdayDate } from "@lib/dates";
+import { fmtWeekdayDate, sentenceCase } from "@lib/dates";
 import { roomImage } from "@lib/images";
 import { Image } from "astro:assets";
 import { render } from "astro:content";
@@ -93,7 +93,9 @@ const title = room.data.forSessions
           <h2>{t("room.sessions")}</h2>
           {days.map((day) => (
             <section>
-              <h3 class="day">{fmtWeekdayDate(day.date, locale)}</h3>
+              <h3 class="day">
+                {sentenceCase(fmtWeekdayDate(day.date, locale))}
+              </h3>
               <SessionList
                 sessions={day.sessions}
                 {year}
@@ -112,13 +114,13 @@ const title = room.data.forSessions
     {
       otherRooms.length > 0 && (
         <p class="others">
-          {t("room.others")}:{" "}
-          {otherRooms.map((r, i) => (
-            <>
-              {i > 0 && ", "}
-              <a href={l(`/${year}/rooms/${slugOf(r)}/`)}>{r.data.name}</a>
-            </>
-          ))}
+          {`${t("room.others")}: `}
+          <span class="inline-list">
+            {otherRooms.map((r) => {
+              const href = l(`/${year}/rooms/${slugOf(r)}/`);
+              return <a {href}>{r.data.name}</a>;
+            })}
+          </span>
         </p>
       )
     }
@@ -173,7 +175,6 @@ const title = room.data.forSessions
 
   .day {
     font-size: var(--text-1);
-    text-transform: capitalize;
     margin-top: var(--space-s);
     padding-bottom: var(--space-3xs);
     border-bottom: 3px solid var(--edition-accent);

--- a/src/components/pages/RoomsIndexPage.astro
+++ b/src/components/pages/RoomsIndexPage.astro
@@ -1,6 +1,6 @@
 ---
 import EditionNotice from "@components/EditionNotice.astro";
-import SectionHeading from "@components/SectionHeading.astro";
+import PageHeader from "@components/PageHeader.astro";
 import { isCurrent } from "@configs/editions";
 import { localizePath, useTranslations, type Locale } from "@i18n/index";
 import BaseLayout from "@layouts/BaseLayout.astro";
@@ -28,13 +28,9 @@ const otherRooms = rooms.filter((r) => !r.data.forSessions);
   {year}
   noCtas={!isCurrent(year)}
 >
-  <div class="container section">
+  <div class="container container--inset section">
     <EditionNotice {year} {locale} />
-    <SectionHeading
-      as="h1"
-      title={t("rooms.title")}
-      kicker={`DevFest Modena ${year}`}
-    />
+    <PageHeader title={t("rooms.title")} badge={`DevFest Modena ${year}`} />
 
     {
       [
@@ -87,6 +83,7 @@ const otherRooms = rooms.filter((r) => !r.data.forSessions);
   .group h2 {
     font-size: var(--text-2);
     margin-bottom: var(--space-s);
+    text-align: center;
   }
 
   .grid {

--- a/src/components/pages/SessionPage.astro
+++ b/src/components/pages/SessionPage.astro
@@ -7,7 +7,7 @@ import { SITE_URL } from "@configs/site";
 import { localizePath, useTranslations, type Locale } from "@i18n/index";
 import BaseLayout from "@layouts/BaseLayout.astro";
 import { getRoomsOfYear, slugOf, yearOf, type Session } from "@lib/content";
-import { fmtTime, fmtWeekdayDate, isoAtVenue } from "@lib/dates";
+import { fmtTime, fmtWeekdayDate, isoAtVenue, sentenceCase } from "@lib/dates";
 import { speakerImage } from "@lib/images";
 import { render } from "astro:content";
 import { getEntries } from "astro:content";
@@ -57,7 +57,7 @@ const jsonLd = [
 ---
 
 <BaseLayout title={session.data.title} {description} {locale} {year} {jsonLd}>
-  <article class="container section">
+  <article class="container container--inset section">
     <EditionNotice {year} {locale} />
     <p class="back">
       <a href={l(`/${year}/sessions/`)}>← {t("session.back")}</a>
@@ -78,7 +78,7 @@ const jsonLd = [
         <dt><Icon name="calendar" size={20} /> {t("session.when")}</dt>
         <dd>
           <span class="fact-strong"
-            >{fmtWeekdayDate(session.data.starts, locale)}</span
+            >{sentenceCase(fmtWeekdayDate(session.data.starts, locale))}</span
           >
           <time datetime={isoAtVenue(session.data.starts)}>
             {fmtTime(session.data.starts, locale)}
@@ -98,15 +98,11 @@ const jsonLd = [
                 ? t("agenda.room")
                 : t("agenda.rooms.simultaneous")}
             </dt>
-            <dd>
-              {sessionRooms.map((room, i) => (
-                <>
-                  {i > 0 && ", "}
-                  <a href={l(`/${year}/rooms/${slugOf(room)}/`)}>
-                    {room.data.name}
-                  </a>
-                </>
-              ))}
+            <dd class="inline-list">
+              {sessionRooms.map((room) => {
+                const href = l(`/${year}/rooms/${slugOf(room)}/`);
+                return <a {href}>{room.data.name}</a>;
+              })}
             </dd>
           </div>
         )
@@ -223,15 +219,15 @@ const jsonLd = [
   }
 
   .title {
-    font-size: var(--text-3);
-    max-width: 26ch;
+    font-size: var(--text-4);
+    max-width: 24ch;
     margin-bottom: var(--space-m);
   }
 
   .facts {
     display: flex;
     flex-wrap: wrap;
-    gap: var(--space-s);
+    gap: var(--space-2xs);
     margin-block: var(--space-m);
   }
 
@@ -241,7 +237,7 @@ const jsonLd = [
     padding: var(--space-xs) var(--space-s);
     border: 1px solid var(--color-border);
     border-radius: var(--radius-m);
-    background: var(--color-surface);
+    background: var(--color-card);
     min-width: 12rem;
   }
 
@@ -267,7 +263,6 @@ const jsonLd = [
 
   .fact-strong {
     font-weight: 700;
-    text-transform: capitalize;
     display: block;
   }
 
@@ -288,7 +283,7 @@ const jsonLd = [
     list-style: none;
     padding: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
     gap: var(--space-s);
   }
 </style>

--- a/src/components/pages/SpeakerPage.astro
+++ b/src/components/pages/SpeakerPage.astro
@@ -173,7 +173,6 @@ const jsonLd = [
     width: 100%;
     height: auto;
     border-radius: var(--radius-l);
-    border: 4px solid var(--edition-accent-soft);
   }
 
   .details {

--- a/src/components/pages/SpeakersPage.astro
+++ b/src/components/pages/SpeakersPage.astro
@@ -1,8 +1,8 @@
 ---
-import Callout from "@components/Callout.astro";
 import EditionNotice from "@components/EditionNotice.astro";
+import PageHeader from "@components/PageHeader.astro";
 import PersonCard from "@components/PersonCard.astro";
-import SectionHeading from "@components/SectionHeading.astro";
+import PromoCard from "@components/PromoCard.astro";
 import { editionOf, isCurrent } from "@configs/editions";
 import { localizePath, useTranslations, type Locale } from "@i18n/index";
 import BaseLayout from "@layouts/BaseLayout.astro";
@@ -28,26 +28,25 @@ const cfs = current ? editionOf(year).callForSpeakers : undefined;
   {year}
   noCtas={!current}
 >
-  <div class="container section">
+  <div class="container container--inset section">
     <EditionNotice {year} {locale} />
-    <SectionHeading
-      as="h1"
+    <PageHeader
       title={t("speakers.title", { year })}
-      kicker="DevFest Modena"
+      badge={`DevFest Modena ${year}`}
+      lead={current ? t("speakers.teaser", { year }) : undefined}
     />
-
-    {current && <p class="teaser">{t("speakers.teaser", { year })}</p>}
 
     {
       cfs?.open && (
-        <Callout variant="info">
-          <p>{t("cfs.text", { year })}</p>
-          <p>
-            <a class="button" href={cfs.url} target="_blank" rel="noopener">
-              {t("cfs.button")}
-            </a>
-          </p>
-        </Callout>
+        <div class="cfs">
+          <PromoCard
+            badge={t("cfs.badge")}
+            title={t("cfs.title")}
+            text={t("cfs.text", { year })}
+            action={{ label: t("cfs.button"), href: cfs.url, external: true }}
+            decor={{ shape: "cross", tone: "pink" }}
+          />
+        </div>
       )
     }
 
@@ -70,18 +69,15 @@ const cfs = current ? editionOf(year).callForSpeakers : undefined;
 </BaseLayout>
 
 <style>
-  .teaser {
-    margin-block: calc(-1 * var(--space-xs)) var(--space-m);
-    color: var(--color-text-muted);
-    max-width: 60ch;
+  .cfs {
+    margin-bottom: var(--space-l);
   }
 
   .grid {
     list-style: none;
     padding: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(13rem, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
     gap: var(--space-s);
-    margin-top: var(--space-m);
   }
 </style>

--- a/src/components/pages/TeamPage.astro
+++ b/src/components/pages/TeamPage.astro
@@ -1,7 +1,7 @@
 ---
 import EditionNotice from "@components/EditionNotice.astro";
+import PageHeader from "@components/PageHeader.astro";
 import PersonCard from "@components/PersonCard.astro";
-import SectionHeading from "@components/SectionHeading.astro";
 import { isCurrent } from "@configs/editions";
 import { useTranslations, type Locale } from "@i18n/index";
 import BaseLayout from "@layouts/BaseLayout.astro";
@@ -47,17 +47,16 @@ const groups = edition.data.roles
   {year}
   noCtas={!isCurrent(year)}
 >
-  <div class="container section">
+  <div class="container container--inset section">
     <EditionNotice {year} {locale} />
-    <SectionHeading
-      as="h1"
+    <PageHeader
       title={t("team.title", { year })}
-      kicker="DevFest Modena"
+      badge={`DevFest Modena ${year}`}
     />
 
     {
       IntroContent && (
-        <div class="prose intro">
+        <div class="prose prose--center intro">
           <IntroContent />
         </div>
       )
@@ -88,7 +87,7 @@ const groups = edition.data.roles
 
 <style>
   .intro {
-    margin-bottom: var(--space-m);
+    margin-bottom: var(--space-l);
   }
 
   .group {
@@ -98,16 +97,14 @@ const groups = edition.data.roles
   .group h2 {
     font-size: var(--text-2);
     margin-bottom: var(--space-s);
-    padding-bottom: var(--space-3xs);
-    border-bottom: 3px solid var(--edition-accent);
-    display: inline-block;
+    text-align: center;
   }
 
   .grid {
     list-style: none;
     padding: 0;
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(12rem, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(11rem, 1fr));
     gap: var(--space-s);
   }
 </style>

--- a/src/content/pages/en/speed-networking.md
+++ b/src/content/pages/en/speed-networking.md
@@ -3,8 +3,6 @@ title: Speed networking
 description: The fastest way to grow your network.
 ---
 
-# Speed networking
-
 Speed networking is an activity designed to spark quick, focused meetings between attendees.
 
 Participants rotate through short one-to-one conversations — 3 minutes each — to introduce themselves, exchange contacts and spot possible professional synergies.

--- a/src/content/pages/en/workshops.md
+++ b/src/content/pages/en/workshops.md
@@ -3,8 +3,6 @@ title: Workshops
 description: Learn by getting your hands dirty.
 ---
 
-# Workshops
-
 Workshops have a limited number of seats, roughly 20–25 depending on the session.
 
 A few days before the event we will email a registration form to the address you used for your ticket.

--- a/src/content/pages/it/speed-networking.md
+++ b/src/content/pages/it/speed-networking.md
@@ -3,8 +3,6 @@ title: Speed networking
 description: Il modo più rapido per espandere la propria rete.
 ---
 
-# Speed networking
-
 Lo speed networking è un'attività pensata per facilitare incontri rapidi e mirati tra i partecipanti.
 
 I partecipanti si alternano in brevi conversazioni one-to-one, 3 minuti ciascuna, per presentarsi, scambiare contatti e individuare possibili sinergie professionali.

--- a/src/content/pages/it/workshops.md
+++ b/src/content/pages/it/workshops.md
@@ -3,8 +3,6 @@ title: Workshop
 description: Per imparare mettendo le mani in pasta.
 ---
 
-# Workshop
-
 I workshop hanno un numero di posti limitato indicativamente a 20-25 a seconda della sessione.
 
 Ti invieremo un form via email per la registrazione ai workshop pochi giorni prima dell'evento, all'indirizzo email col quale hai preso i biglietti.

--- a/src/i18n/ui.ts
+++ b/src/i18n/ui.ts
@@ -17,11 +17,13 @@ export const ui = {
     "nav.lang.label": "Lingua",
 
     "home.claim":
-      "Due giornate di talk, workshop e community nel cuore dell'Emilia.",
-    "home.hero.tickets": "Prendi il biglietto",
+      "Due giorni di conferenze multidisciplinari, workshop e collaborazione. Unisciti a sviluppatori, designer e appassionati per plasmare il futuro del digitale.",
+    "home.hero.tickets": "Riserva biglietto",
     "home.hero.agenda": "Scopri l'agenda",
     "home.free": "Evento gratuito",
-    "home.stats.title": "Il nostro {year}",
+    "home.gallery": "Momenti dalle edizioni passate",
+    "home.intro.cta": "Consulta agenda",
+    "home.stats.title": "Il nostro DevFest {year}",
     "home.stats.rooms": "Sale",
     "home.stats.speakers": "Speaker",
     "home.stats.workshops": "Workshop",
@@ -32,7 +34,8 @@ export const ui = {
     "home.communities.all": "Tutte le community",
     "home.editions.title": "Edizioni precedenti",
 
-    "cfs.title": "Call for speakers",
+    "cfs.badge": "Diventa speaker",
+    "cfs.title": "Call4Speakers",
     "cfs.text":
       "Vuoi salire sul palco del DevFest Modena {year}? La call for speakers è aperta: fatti avanti!",
     "cfs.button": "Proponi una sessione",
@@ -43,10 +46,11 @@ export const ui = {
     "cta.tickets.text2":
       "Prendi il tuo biglietto gratuito e assicurati un posto all'evento.",
     "cta.tickets.button": "Prendi il biglietto",
+    "cta.cv.badge": "Estendi la tua rete",
     "cta.cv.title": "Manda il curriculum",
     "cta.cv.text":
       "Invia il tuo curriculum, lo condivideremo con le aziende in cerca di collaboratori.",
-    "cta.cv.button": "Invia qui",
+    "cta.cv.button": "Invia il tuo CV",
 
     "footer.description":
       "Un grande evento di programmazione e di tecnologia al centro dell'Emilia, nato dalle comunità locali.",
@@ -176,11 +180,13 @@ export const ui = {
     "nav.lang.label": "Language",
 
     "home.claim":
-      "Two days of talks, workshops and community in the heart of Emilia, Italy.",
-    "home.hero.tickets": "Get your ticket",
+      "Two days of multidisciplinary conferences, workshops and collaboration. Join developers, designers and enthusiasts shaping the future of digital.",
+    "home.hero.tickets": "Book your ticket",
     "home.hero.agenda": "Browse the agenda",
     "home.free": "Free event",
-    "home.stats.title": "Our {year}",
+    "home.gallery": "Moments from past editions",
+    "home.intro.cta": "Browse the agenda",
+    "home.stats.title": "Our DevFest {year}",
     "home.stats.rooms": "Rooms",
     "home.stats.speakers": "Speakers",
     "home.stats.workshops": "Workshops",
@@ -191,7 +197,8 @@ export const ui = {
     "home.communities.all": "All communities",
     "home.editions.title": "Previous editions",
 
-    "cfs.title": "Call for speakers",
+    "cfs.badge": "Become a speaker",
+    "cfs.title": "Call4Speakers",
     "cfs.text":
       "Would you like to speak at DevFest Modena {year}? The call for speakers is open: step forward!",
     "cfs.button": "Submit a session",
@@ -200,10 +207,11 @@ export const ui = {
     "cta.tickets.text1": "Registrations for DevFest Modena {year} are open.",
     "cta.tickets.text2": "Get your free ticket and secure your seat.",
     "cta.tickets.button": "Get your ticket",
+    "cta.cv.badge": "Grow your network",
     "cta.cv.title": "Send your resume",
     "cta.cv.text":
       "Share your resume with us: we will pass it on to companies looking for talent.",
-    "cta.cv.button": "Send it here",
+    "cta.cv.button": "Send your CV",
 
     "footer.description":
       "A great programming and technology event in the heart of Emilia, born from local communities.",

--- a/src/lib/dates.ts
+++ b/src/lib/dates.ts
@@ -4,6 +4,14 @@ import { langTag } from "@i18n/index";
 /** All event times are wall-clock times at the venue. */
 export const EVENT_TZ = "Europe/Rome";
 
+/**
+ * Sentence-case a formatted date. Italian weekdays and months are lower
+ * case, so only the first letter is lifted (never `text-transform`).
+ */
+export function sentenceCase(text: string): string {
+  return text.charAt(0).toUpperCase() + text.slice(1);
+}
+
 export function fmtTime(date: Date, locale: Locale): string {
   return new Intl.DateTimeFormat(langTag(locale), {
     hour: "2-digit",

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -1,5 +1,6 @@
 ---
-import SectionHeading from "@components/SectionHeading.astro";
+import Decor from "@components/Decor.astro";
+import PageHeader from "@components/PageHeader.astro";
 import { CURRENT_YEAR } from "@configs/editions";
 import { useTranslations } from "@i18n/index";
 import BaseLayout from "@layouts/BaseLayout.astro";
@@ -14,16 +15,17 @@ const links = [
 ---
 
 <BaseLayout title={t("notfound.title")} locale="it" noCtas noIndex>
-  <div class="container section wrap">
-    <p class="code" aria-hidden="true">4<span class="o"></span>4</p>
-    <SectionHeading as="h1" title={t("notfound.title")} />
-    <p>{t("notfound.text")}</p>
-    <p lang="en" class="muted">{t("notfound.text")} · Page not found.</p>
+  <div class="container container--narrow section wrap">
+    <p class="code" aria-hidden="true">
+      4<span class="o"></span>4
+    </p>
+    <Decor shape="cross" tone="pink" size={2.25} />
+    <PageHeader title={t("notfound.title")} lead={t("notfound.text")} />
     <p class="actions">
       <a class="button" href="/">{t("notfound.home")}</a>
     </p>
     <p class="muted">{t("notfound.links")}:</p>
-    <ul class="links">
+    <ul class="links" role="list">
       {
         links.map((link) => (
           <li>
@@ -44,6 +46,7 @@ const links = [
     text-align: center;
     min-height: 55vh;
     align-content: center;
+    gap: var(--space-xs);
   }
 
   .code {
@@ -52,6 +55,7 @@ const links = [
     gap: 0.1em;
     font-size: var(--text-6);
     font-weight: 700;
+    letter-spacing: var(--tracking-tight);
     color: var(--color-ink);
     line-height: 1;
   }
@@ -62,10 +66,6 @@ const links = [
     border-radius: 50%;
     border: 0.16em solid var(--g-red);
     display: inline-block;
-  }
-
-  .actions {
-    margin-block: var(--space-s);
   }
 
   .muted {
@@ -80,6 +80,5 @@ const links = [
     flex-wrap: wrap;
     justify-content: center;
     gap: var(--space-2xs);
-    margin-top: var(--space-2xs);
   }
 </style>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -61,6 +61,7 @@ h3,
 h4 {
   color: var(--color-ink);
   line-height: var(--leading-title);
+  letter-spacing: var(--tracking-tight);
   text-wrap: balance;
   font-weight: 700;
 }
@@ -87,14 +88,24 @@ a:hover {
 
 ::selection {
   background: var(--g-yellow-soft);
-  color: light-dark(oklch(24% 0.004 270), oklch(93% 0.004 90));
+  color: var(--color-ink);
 }
 
 /* ---- Layout primitives ---- */
 
+/* Outer rail: panels, the footer and the photo strip reach this edge. */
 .container {
-  width: min(100% - 2 * var(--space-s), var(--container));
+  width: min(100% - 2 * var(--gutter), var(--container));
   margin-inline: auto;
+}
+
+/* Copy and card grids breathe a little inside the panels above them. */
+.container--inset {
+  max-width: var(--container-inset);
+}
+
+.container--narrow {
+  max-width: var(--container-narrow);
 }
 
 .section {
@@ -105,58 +116,106 @@ a:hover {
   padding-block: var(--space-l);
 }
 
-/* ---- Headings with the four-color DevFest accent ---- */
+.section--flush {
+  padding-block: 0;
+}
+
+.stack {
+  display: grid;
+  gap: var(--space-s);
+}
+
+/*
+ * Comma-separated run of links. Flex drops the whitespace-only text nodes
+ * the template indentation would otherwise render before each comma.
+ */
+.inline-list {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 0 0.3em;
+}
+
+.inline-list > *:not(:last-child)::after {
+  content: ",";
+}
+
+/* ---- Panels: the periwinkle blocks that carry the key messages ---- */
+
+.panel {
+  background: var(--color-panel);
+  border-radius: var(--radius-l);
+  padding: clamp(var(--space-m), 4vi, var(--space-2xl)) var(--space-m);
+}
+
+/* Stacked, centered content (the default reading of a panel). */
+.panel--center {
+  display: grid;
+  justify-items: center;
+  text-align: center;
+}
+
+/* Copy on one side, media on the other. */
+.panel--split {
+  display: grid;
+  grid-template-columns: 1fr minmax(0, 20rem);
+  align-items: center;
+  gap: var(--space-l);
+  padding-block: var(--space-l);
+}
+
+@media (max-width: 47.9375em) {
+  .panel--split {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ---- Section headings ---- */
 
 .kicker {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5em;
-  font-size: var(--text--1);
+  display: inline-block;
+  font-size: var(--text--2);
   font-weight: 700;
-  letter-spacing: 0.06em;
+  letter-spacing: var(--tracking-wide);
   text-transform: uppercase;
   color: var(--color-text-muted);
 }
 
-.kicker::before {
-  content: "";
-  width: 0.55em;
-  height: 0.55em;
-  border-radius: 50%;
-  background: var(--edition-accent);
-}
-
-.four-dots {
+/* Hairline rule punctuated by the four Google dots. */
+.dot-divider {
   display: flex;
-  gap: 0.45rem;
+  align-items: center;
+  gap: 0.4rem;
+  width: min(100%, 22rem);
+  color: var(--color-border-strong);
 }
 
-.four-dots::before,
-.four-dots::after {
+.dot-divider::before,
+.dot-divider::after {
   content: "";
+  flex: 1;
+  height: 1px;
+  background: currentColor;
 }
 
-.four-dots::before,
-.four-dots::after,
-.four-dots i {
-  width: 0.55rem;
-  height: 0.55rem;
+.dot-divider i {
+  width: 0.5rem;
+  height: 0.5rem;
   border-radius: 50%;
 }
 
-.four-dots::before {
+.dot-divider i:nth-of-type(1) {
   background: var(--g-blue);
 }
 
-.four-dots i:nth-of-type(1) {
+.dot-divider i:nth-of-type(2) {
   background: var(--g-red);
 }
 
-.four-dots i:nth-of-type(2) {
+.dot-divider i:nth-of-type(3) {
   background: var(--g-yellow);
 }
 
-.four-dots::after {
+.dot-divider i:nth-of-type(4) {
   background: var(--g-green);
 }
 
@@ -167,97 +226,129 @@ a:hover {
   align-items: center;
   justify-content: center;
   gap: 0.5em;
-  padding: 0.7em 1.5em;
-  border: 2px solid transparent;
+  padding: 0.85em 1.6em;
+  border: 1px solid transparent;
   border-radius: var(--radius-full);
-  background: var(--g-blue);
-  color: var(--color-on-accent);
+  background: var(--color-action);
+  color: var(--color-on-action);
   font: inherit;
-  font-size: var(--text-0);
+  font-size: var(--text--1);
   font-weight: 700;
+  line-height: 1.2;
+  text-align: center;
   text-decoration: none;
   cursor: pointer;
   transition:
-    transform var(--transition),
-    box-shadow var(--transition),
     background var(--transition),
-    border-color var(--transition);
+    border-color var(--transition),
+    color var(--transition),
+    box-shadow var(--transition);
 }
 
 .button:hover {
-  transform: translateY(-2px);
-  box-shadow: var(--shadow-1);
+  box-shadow: var(--shadow-2);
   text-decoration: none;
 }
 
-.button:active {
-  transform: translateY(0);
-}
-
 .button--secondary {
-  background: transparent;
+  background: var(--color-card);
   border-color: var(--color-border-strong);
   color: var(--color-ink);
 }
 
 .button--secondary:hover {
-  background: var(--color-surface);
+  border-color: var(--color-ink);
+  box-shadow: none;
 }
 
+/* For use on the dark footer / ink surfaces */
 .button--light {
-  background: oklch(99% 0 0);
-  color: oklch(24% 0.004 270);
+  background: oklch(100% 0 0);
+  color: oklch(19% 0.004 270);
 }
 
-/* ---- Chips & badges ---- */
+.button--block {
+  width: 100%;
+}
+
+/* ---- Badges (static pills) & chips (interactive pills) ---- */
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4em;
+  padding: 0.35em 0.85em;
+  border-radius: var(--radius-full);
+  background: var(--color-surface-2);
+  color: var(--color-text);
+  font-size: var(--text--2);
+  font-weight: 700;
+  line-height: 1.3;
+  white-space: nowrap;
+}
+
+.badge--accent {
+  background: var(--edition-accent-soft);
+  color: var(--edition-accent-ink);
+}
+
+.badge--blue {
+  background: var(--g-blue-soft);
+  color: var(--g-blue-ink);
+}
+
+.badge--green {
+  background: var(--g-green-soft);
+  color: var(--g-green-ink);
+}
+
+.badge--yellow {
+  background: var(--g-yellow-soft);
+  color: var(--g-yellow-ink);
+}
+
+.badge--red {
+  background: var(--g-red-soft);
+  color: var(--g-red-ink);
+}
 
 .chip {
   display: inline-flex;
   align-items: center;
   gap: 0.4em;
-  padding: 0.2em 0.75em;
+  padding: 0.45em 1em;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-full);
-  background: var(--color-surface);
+  background: var(--color-card);
   color: var(--color-text);
   font-size: var(--text--1);
   font-weight: 400;
   text-decoration: none;
   white-space: nowrap;
+  transition:
+    border-color var(--transition),
+    color var(--transition);
 }
 
 a.chip:hover {
-  border-color: var(--color-border-strong);
+  border-color: var(--color-ink);
+  color: var(--color-ink);
   text-decoration: none;
 }
 
-.chip--blue {
-  background: var(--g-blue-soft);
-  border-color: transparent;
-}
-
-.chip--green {
-  background: var(--g-green-soft);
-  border-color: transparent;
-}
-
-.chip--yellow {
-  background: var(--g-yellow-soft);
-  border-color: transparent;
-}
-
-.chip--red {
-  background: var(--g-red-soft);
-  border-color: transparent;
+.chip--active {
+  border-color: var(--color-ink);
+  color: var(--color-ink);
+  font-weight: 700;
 }
 
 /* ---- Cards ---- */
 
 .card {
   display: block;
-  background: var(--color-surface);
+  background: var(--color-card);
   border: 1px solid var(--color-border);
-  border-radius: var(--radius-l);
+  border-radius: var(--radius-m);
   padding: var(--space-s);
   text-decoration: none;
   color: inherit;
@@ -268,10 +359,28 @@ a.chip:hover {
 }
 
 a.card:hover {
-  transform: translateY(-3px);
+  transform: translateY(-2px);
   box-shadow: var(--shadow-2);
   border-color: var(--color-border-strong);
   text-decoration: none;
+}
+
+/* Neutral white plate behind a logo, whatever the theme. */
+.logo-tile {
+  display: grid;
+  place-items: center;
+  background: var(--color-logo-tile);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-m);
+  padding: var(--space-xs);
+}
+
+.logo-tile img {
+  max-width: 100%;
+  max-height: 100%;
+  width: auto;
+  height: auto;
+  object-fit: contain;
 }
 
 /* ---- Markdown content ---- */
@@ -297,6 +406,10 @@ a.card:hover {
 
 .prose h3 {
   font-size: var(--text-1);
+}
+
+.prose > :first-child {
+  margin-top: 0;
 }
 
 .prose p,
@@ -343,12 +456,26 @@ a.card:hover {
   border-radius: var(--radius-m);
   padding: var(--space-2xs) var(--space-s);
   margin-block: 0.6em;
-  background: var(--color-surface);
+  background: var(--color-card);
 }
 
 .prose summary {
   cursor: pointer;
-  font-weight: 400;
+  font-weight: 700;
+  color: var(--color-ink);
+}
+
+/* Centred copy inside panels. */
+.prose--center {
+  max-width: 62ch;
+  margin-inline: auto;
+  text-align: center;
+}
+
+.prose--center ul,
+.prose--center ol {
+  list-style-position: inside;
+  padding-inline-start: 0;
 }
 
 /* ---- Accessibility helpers ---- */
@@ -409,6 +536,7 @@ a.card:hover {
   .site-footer,
   .cta-tickets,
   .cta-cv,
+  .decor,
   .skip-link {
     display: none !important;
   }

--- a/src/styles/themes.css
+++ b/src/styles/themes.css
@@ -8,14 +8,17 @@
 [data-edition="2026"] {
   --edition-accent: var(--g-blue);
   --edition-accent-soft: var(--g-blue-soft);
+  --edition-accent-ink: var(--g-blue-ink);
 }
 
 [data-edition="2025"] {
   --edition-accent: var(--g-green);
   --edition-accent-soft: var(--g-green-soft);
+  --edition-accent-ink: var(--g-green-ink);
 }
 
 [data-edition="2024"] {
   --edition-accent: var(--g-red);
   --edition-accent-soft: var(--g-red-soft);
+  --edition-accent-ink: var(--g-red-ink);
 }

--- a/src/styles/variables.css
+++ b/src/styles/variables.css
@@ -1,6 +1,8 @@
 /*
  * DevFest Modena design tokens.
  * Colors are oklch and adapt to the OS theme via light-dark().
+ * The design is authored light-first: the dark values are derived so the
+ * same components keep working, never the other way round.
  * Per-edition accents can be overridden in themes.css ([data-edition="…"]).
  */
 
@@ -9,35 +11,56 @@
 
   /* ---- Google brand palette (primitives) ---- */
   --g-blue: oklch(62% 0.19 260);
-  --g-green: oklch(64% 0.17 150);
-  --g-yellow: oklch(83% 0.16 85);
-  --g-red: oklch(64% 0.2 27);
+  --g-green: oklch(63% 0.16 149);
+  --g-yellow: oklch(82% 0.16 83);
+  --g-red: oklch(63% 0.21 29);
+  /* Extra DevFest accent, only used by the ornamental shapes */
+  --g-pink: oklch(72% 0.17 5);
+
+  /* Readable-on-pastel versions, used for badge text */
+  --g-blue-ink: light-dark(oklch(45% 0.17 262), oklch(85% 0.09 250));
+  --g-green-ink: light-dark(oklch(48% 0.13 150), oklch(85% 0.09 150));
+  --g-yellow-ink: light-dark(oklch(52% 0.11 75), oklch(88% 0.09 90));
+  --g-red-ink: light-dark(oklch(48% 0.17 28), oklch(85% 0.09 25));
 
   /* Pastel halftones, dimmed on dark backgrounds */
-  --g-blue-soft: light-dark(oklch(92% 0.05 215), oklch(34% 0.05 240));
-  --g-green-soft: light-dark(oklch(93% 0.07 145), oklch(34% 0.06 150));
-  --g-yellow-soft: light-dark(oklch(93% 0.08 92), oklch(36% 0.06 85));
-  --g-red-soft: light-dark(oklch(90% 0.045 20), oklch(34% 0.05 25));
+  --g-blue-soft: light-dark(oklch(95% 0.025 260), oklch(31% 0.05 260));
+  --g-green-soft: light-dark(oklch(95.5% 0.03 155), oklch(30% 0.05 155));
+  --g-yellow-soft: light-dark(oklch(97% 0.035 95), oklch(32% 0.05 88));
+  --g-red-soft: light-dark(oklch(94% 0.025 25), oklch(31% 0.05 25));
 
   /* ---- Semantic colors ---- */
-  --color-bg: light-dark(oklch(99% 0.002 90), oklch(19% 0.008 270));
-  --color-surface: light-dark(oklch(97.5% 0.003 90), oklch(24% 0.01 270));
-  --color-surface-2: light-dark(oklch(95.5% 0.004 90), oklch(28% 0.012 270));
-  --color-ink: light-dark(oklch(24% 0.004 270), oklch(93% 0.004 90));
-  --color-text: light-dark(oklch(30% 0.004 270), oklch(88% 0.004 90));
-  --color-text-muted: light-dark(oklch(47% 0.006 270), oklch(72% 0.008 270));
-  --color-border: light-dark(oklch(88% 0.005 270), oklch(34% 0.01 270));
-  --color-border-strong: light-dark(oklch(30% 0.004 270), oklch(80% 0.005 90));
-  --color-link: light-dark(oklch(50% 0.19 262), oklch(78% 0.11 245));
-  --color-on-accent: oklch(99% 0 0);
+  --color-bg: light-dark(oklch(100% 0 0), oklch(16% 0.008 275));
+  /* Large rounded content blocks (hero panels, tickets, intro) */
+  --color-panel: light-dark(oklch(94.5% 0.022 278), oklch(22% 0.018 275));
+  /* Cards sitting on either the page or a panel */
+  --color-card: light-dark(oklch(100% 0 0), oklch(21% 0.012 275));
+  --color-surface: light-dark(oklch(97.5% 0.003 280), oklch(24% 0.012 275));
+  --color-surface-2: light-dark(oklch(95% 0.004 280), oklch(28% 0.014 275));
+  --color-ink: light-dark(oklch(19% 0.004 270), oklch(97% 0.002 90));
+  --color-text: light-dark(oklch(38% 0.006 270), oklch(88% 0.004 90));
+  --color-text-muted: light-dark(oklch(52% 0.008 270), oklch(72% 0.008 270));
+  --color-border: light-dark(oklch(92% 0.004 280), oklch(30% 0.012 275));
+  --color-border-strong: light-dark(oklch(82% 0.006 280), oklch(45% 0.014 275));
+  --color-link: light-dark(oklch(48% 0.19 262), oklch(80% 0.11 245));
+
+  /* Primary action: ink on light, inverted on dark so it stays legible */
+  --color-action: light-dark(oklch(19% 0.004 270), oklch(97% 0.002 90));
+  --color-on-action: light-dark(oklch(100% 0 0), oklch(16% 0.008 275));
 
   /* Footer keeps the "ink" identity in both schemes */
-  --color-footer-bg: light-dark(oklch(24% 0.01 270), oklch(15% 0.008 270));
-  --color-footer-text: oklch(90% 0.004 90);
+  --color-footer-bg: light-dark(oklch(21% 0.004 270), oklch(13% 0.008 275));
+  --color-footer-text: oklch(91% 0.003 90);
+  --color-footer-muted: oklch(74% 0.005 270);
+  --color-footer-border: oklch(100% 0 0 / 0.14);
+
+  /* Neutral tile behind logos, white in both schemes (logos assume it) */
+  --color-logo-tile: oklch(100% 0 0);
 
   /* Per-edition accent (see themes.css) */
   --edition-accent: var(--g-blue);
   --edition-accent-soft: var(--g-blue-soft);
+  --edition-accent-ink: var(--g-blue-ink);
 
   /* ---- Typography ---- */
   /* Fluid scale, Utopia 600px→1140px (18→20px base, 1.2→1.25 ratio) */
@@ -45,18 +68,23 @@
     "Google Sans Display", "Google Sans", system-ui, -apple-system, "Segoe UI",
     Roboto, sans-serif;
   --text--2: clamp(0.781rem, 0.76rem + 0.056vi, 0.8rem);
-  --text--1: clamp(0.938rem, 0.868rem + 0.185vi, 1rem);
-  --text-0: clamp(1.125rem, 0.986rem + 0.37vi, 1.25rem);
-  --text-1: clamp(1.35rem, 1.114rem + 0.63vi, 1.563rem);
-  --text-2: clamp(1.62rem, 1.25rem + 0.987vi, 1.953rem);
-  --text-3: clamp(1.944rem, 1.391rem + 1.474vi, 2.441rem);
-  --text-4: clamp(2.333rem, 1.534rem + 2.13vi, 3.052rem);
-  --text-5: clamp(2.799rem, 1.671rem + 3.008vi, 3.815rem);
-  --text-6: clamp(3.359rem, 1.794rem + 4.175vi, 4.768rem);
+  --text--1: clamp(0.875rem, 0.83rem + 0.12vi, 0.938rem);
+  --text-0: clamp(1rem, 0.958rem + 0.111vi, 1.063rem);
+  --text-1: clamp(1.125rem, 1.028rem + 0.259vi, 1.266rem);
+  --text-2: clamp(1.35rem, 1.163rem + 0.5vi, 1.62rem);
+  --text-3: clamp(1.62rem, 1.31rem + 0.827vi, 2.074rem);
+  --text-4: clamp(1.944rem, 1.464rem + 1.28vi, 2.653rem);
+  --text-5: clamp(2.333rem, 1.617rem + 1.91vi, 3.397rem);
+  --text-6: clamp(2.8rem, 1.75rem + 2.8vi, 4.348rem);
+  /* Display size, only for the home hero */
+  --text-display: clamp(3.25rem, 1.55rem + 4.53vi, 5.75rem);
 
-  --leading-solid: 1.05;
-  --leading-title: 1.2;
-  --leading-copy: 1.55;
+  --leading-solid: 0.98;
+  --leading-title: 1.15;
+  --leading-copy: 1.6;
+
+  --tracking-tight: -0.025em;
+  --tracking-wide: 0.06em;
 
   /* ---- Space (fluid) ---- */
   --space-3xs: 0.31rem;
@@ -70,17 +98,20 @@
   --space-3xl: clamp(6.75rem, 5.5rem + 3.33vi, 7.88rem);
 
   /* ---- Shape & effects ---- */
-  --radius-s: 0.625rem;
-  --radius-m: 1rem;
-  --radius-l: 1.5rem;
+  --radius-s: 0.75rem;
+  --radius-m: 1.25rem;
+  --radius-l: 1.75rem;
   --radius-full: 999rem;
-  --shadow-1:
-    0 1px 2px oklch(20% 0.01 270 / 0.08), 0 2px 8px oklch(20% 0.01 270 / 0.08);
+  --shadow-1: 0 1px 2px oklch(20% 0.01 270 / 0.06);
   --shadow-2:
-    0 2px 4px oklch(20% 0.01 270 / 0.1), 0 12px 28px oklch(20% 0.01 270 / 0.14);
+    0 2px 4px oklch(20% 0.01 270 / 0.06), 0 12px 28px oklch(20% 0.01 270 / 0.1);
   --transition: 160ms ease;
 
   /* ---- Layout ---- */
-  --container: 74rem;
-  --container-narrow: 48rem;
+  /* Outer width: panels, footer and the photo strip reach this edge. */
+  --container: 72rem;
+  /* Inner width: cards and copy sit slightly inside the panels. */
+  --container-inset: 64rem;
+  --container-narrow: 46rem;
+  --gutter: var(--space-s);
 }


### PR DESCRIPTION
> [!NOTE]
> **PR stacked su #62.** La base è `claude/devfest-modena-astro-migration-9908b0`: il diff contiene solo il restyling. Va mergiata dopo #62 (o rebasata su `develop` se #62 viene mergiata prima).

Migrazione della UI al design fornito dal designer. La base di codice Astro di #62 resta invariata nella struttura: cambiano token, componenti condivisi e layout delle pagine.

## Il linguaggio visivo

| Elemento    | Scelta |
| ----------- | ------ |
| Sfondo      | Pagina bianca, **pannelli pervinca** (`--color-panel`) per i blocchi chiave |
| Card        | Bianche, bordo hairline 1px, raggio ampio, nessuna ombra a riposo |
| Bottoni     | Pill; **primario = ink (quasi nero)**, **secondario = outline su bianco** |
| Badge       | Pill con tinta pastello Google e testo scuro coordinato |
| Titoli      | Google Sans Display 700, tracking stretto, centrati nelle sezioni |
| Accenti     | I quattro colori Google usati come _punteggiatura_ (divider a pallini, sottolineature delle statistiche) |
| Decorazioni | Forme geometriche piatte (freccia, croce, quadrati) — `Decor.astro` |

Tutto passa dai token in `src/styles/variables.css`: nessun componente scrive colori a mano. `docs/ui-redesign.md` raccoglie il linguaggio, le regole di layout e la checklist completa.

## Cosa cambia

**Fondamenta** — nuova palette semantica (`--color-panel` / `--color-card` / `--color-action`), colori "ink" per i badge, token di tracking, raggi più ampi, due binari di larghezza (`.container` esterno, `.container--inset` interno). In `global.css` arrivano i primitivi condivisi: `.panel`, `.badge`, `.chip`, `.card`, `.logo-tile`, `.dot-divider`, `.inline-list`.

**Componenti** — Header bianco con il marchio `{DevFest}`, nav semplice e CTA ink; footer scuro a quattro colonne con barra finale; nuovi `Decor`, `Gallery`, `PromoCard`, `PageHeader`; `Statistics`, `PartnerGrid`, `CommunitiesGrid`, `PersonCard`, `SessionList`, `Callout`, `CtaTickets` e `CtaCv` rivestiti sul nuovo linguaggio.

**Pagine** — home ricostruita (hero, pannello intro, striscia foto, call4speakers, statistiche, partner, community, edizioni) e tutte le pagine interne allineate al ritmo del `PageHeader` condiviso. Le pagine non incluse negli screenshot (agenda, sessione, speaker, sale, location, FAQ, archivio, 404) sono state dedotte dallo stesso linguaggio.

**Copy** — le stringhe i18n IT/EN seguono il testo del design (claim dell'hero, "Riserva biglietto", "Call4Speakers", "Estendi la tua rete", "Invia il tuo CV").

## Difetti trovati e sistemati lungo la strada

- Le date italiane usavano `text-transform: capitalize` e uscivano come "4 E 5 Ottobre": ora passano da `sentenceCase()` in TS.
- Gli elenchi di link separati da virgola mostravano uno spazio prima della virgola (whitespace del template): ora la virgola arriva da `.inline-list`.
- `workshops.md` e `speed-networking.md` ripetevano il titolo come secondo `h1`.
- Lo script "in corso" dell'agenda era annidato in un'espressione JSX che Prettier non riusciva a parsare: ora è fuori e si attiva con `data-agenda-live`.

## Verifica

- `pnpm build` → 461 pagine, nessun errore; `astro check` → 0 errori, 0 warning; Prettier pulito su tutto `src/`.
- Controllo visivo di home, agenda, sessione, team, speaker, sale, location, FAQ, archivio, hub edizione, pagine markdown e 404, in IT ed EN.
- Responsive a 375 / 768 / 1280px e passata in dark mode (il design è light-only, il dark è derivato dagli stessi token).
- Accessibilità: un solo `h1` per pagina, landmark etichettati, alt su tutte le immagini, focus ring visibile, contrasto WCAG AA in entrambi gli schemi (coppia più bassa misurata 5,15:1).

> [!IMPORTANT]
> Il commit è **non firmato**: in questa sessione GPG non ha potuto aprire il pinentry. Se il repo richiede commit firmati, basta un `git commit --amend -S` prima del merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)